### PR TITLE
fix(using-coreos): fix sudo command

### DIFF
--- a/using-coreos/index.md
+++ b/using-coreos/index.md
@@ -55,7 +55,7 @@ The configuration file format for systemd is straight forward. Lets create a sim
 First, you will need to run all of this as `root` since you are modifying system state:
 
 ```
-sudo su
+sudo -i
 ```
 
 Create a file called `/media/state/units/hello.service`


### PR DESCRIPTION
the - from 'sudo su -' was missing and @jeremyvisser pointed out that sudo -i
is equivalent. Use that instead. Fixes #13
