### PR TITLE
fix(sdk): use the official repo tool

### DIFF
--- a/sdk/index.md
+++ b/sdk/index.md
@@ -70,7 +70,7 @@ Initialize the .repo directory with the manifest that describes all of the git
 repos required to get started.
 
 ```
-repo init -u https://github.com/coreos/manifest.git -g minilayout --repo-url  https://git.chromium.org/git/external/repo.git
+repo init -u https://github.com/coreos/manifest.git -g minilayout --repo-url https://android.googlesource.com/tools/repo
 ```
 
 Synchronize all of the required git repos from the manifest.


### PR DESCRIPTION
chromium pushed a tag that breaks the sdk bring-up process. Use the upstream
repo tool to fix this.
