### PR TITLE
Fix point 7 under "Launching a test cluster".

### DIFF
--- a/ec2/index.md
+++ b/ec2/index.md
@@ -106,7 +106,7 @@ We will be launching three instances, with a shared token (via a gist url) in th
    * "Continue"
 6. Tags
    * "Continue"
-7 Create Key Pair
+7. Create Key Pair
    * Choose a key of your choice, it will be added in addition to the one in the gist.
    * "Continue"
 8. Choose one or more of your existing Security Groups


### PR DESCRIPTION
Point 7 was missing a dot after the number 7, resulting in Markdown not rendering it as a separate <li>.
