### PR TITLE
fix(google-compute-engine): Change hard-coded versions to template variables

### DIFF
--- a/google-compute-engine/index.md
+++ b/google-compute-engine/index.md
@@ -4,7 +4,7 @@ slug: google-compute-engine
 title: Documentation - Google Compute Engine
 ---
 
-# Running CoreOS on Google Compute Engine
+# Running CoreOS {{ site.version-string }} on Google Compute Engine
 
 CoreOS on Google Compute Engine (GCE) is currently in heavy development and actively being tested. The current disk image is listed below and relies on GCE's recently announced [Advanced OS Support][gce-advanced-os]. Each time a new update is released, your machines will [automatically upgrade themselves]({{ site.url }}/using-coreos/updates).
 
@@ -17,15 +17,13 @@ You will need to [install gcutil][gcutil-documentation] before proceeding.
 
 At the moment CoreOS images are not publicly listed in GCE and must be added to your own account from a raw disk image published in Google Cloud Storage:
 
-<!-- FIXME: After launch does the empty preferred_kernel option still need to be set? -->
-
-    gcutil --project=<project-id> addimage --description="CoreOS 153.0.0" coreos-production-v153 gs://storage.core-os.net/coreos/amd64-generic/153.0.0/coreos_production_gce.tar.gz
+    gcutil --project=<project-id> addimage --description="CoreOS {{ site.version-string }}" coreos-production-v{{ site.gce-version-id }} gs://storage.core-os.net/coreos/amd64-generic/{{ site.version-string }}/coreos_production_gce.tar.gz
 
 ## Instance creation
 
 New instances can now be created using the image created above:
 
-    gcutil --project=<project-id> addinstance <instance-name> --image=coreos-production-v153 --persistent_boot_disk
+    gcutil --project=<project-id> addinstance <instance-name> --image=coreos-production-v{{ site.gce-version-id }} --persistent_boot_disk
 
 ## SSH
 


### PR DESCRIPTION
Do not merge until after v159 or later has been promoted to dev-channel.
