### PR TITLE
Corrected the SSH login for the libvirt VM and adapted the example IP to...

### DIFF
--- a/running-coreos/platforms/libvirt/index.md
+++ b/running-coreos/platforms/libvirt/index.md
@@ -131,7 +131,7 @@ inside will be picked up by CoreOS.
 
 Once the virtual machine has started you can log in via SSH:
 
-    ssh -l core -p 2222 localhost
+    ssh core@203.0.113.2
 
 ### SSH Config
 


### PR DESCRIPTION
... the one used in the 'run.sh' example above.
