### PR TITLE
On qemu docs, pipe image directly to bzcat

### DIFF
--- a/running-coreos/platforms/qemu/index.md
+++ b/running-coreos/platforms/qemu/index.md
@@ -74,9 +74,8 @@ format) and the wrapper shell script to start QEMU.
 
     mkdir coreos; cd coreos
     wget http://storage.core-os.net/coreos/amd64-generic/dev-channel/coreos_production_qemu.sh
-    wget http://storage.core-os.net/coreos/amd64-generic/dev-channel/coreos_production_qemu_image.img.bz2
+    wget http://storage.core-os.net/coreos/amd64-generic/dev-channel/coreos_production_qemu_image.img.bz2 -O - | bzcat > coreos_production_qemu_image.img
     chmod +x coreos_production_qemu.sh
-    bunzip2 coreos_production_qemu_image.img.bz2
 
 Starting is as simple as:
 


### PR DESCRIPTION
Saves ~200MB of disk space, and one command-line instruction :)
(We could use `curl` to avoid the `-O -` parameter to `wget`, but I think it's a bit weird to use `wget` in one line and then `curl` on the next one)
