### PR TITLE
Update Vagrant download location

### DIFF
--- a/running-coreos/platforms/vagrant/index.md
+++ b/running-coreos/platforms/vagrant/index.md
@@ -20,7 +20,7 @@ install packages available for Windows, Linux and OSX. Find the latest
 installer on the [Vagrant downloads page][vagrant]. Be sure to get
 version 1.2.3 or greater.
 
-[vagrant]: http://downloads.vagrantup.com/
+[vagrant]: http://www.vagrantup.com/downloads.html
 
 ## Startup CoreOS
 


### PR DESCRIPTION
http://downloads.vagrantup.com/ is now a place for _old_ versions of vagrant. http://www.vagrantup.com/downloads.html has the new hotness.
