### PR TITLE
no wget on OS X

### DIFF
--- a/running-coreos/platforms/vmware/index.md
+++ b/running-coreos/platforms/vmware/index.md
@@ -22,7 +22,7 @@ This is a rough sketch that should work on OSX and Linux:
 
 ```
 curl -O http://storage.core-os.net/coreos/amd64-generic/dev-channel/coreos_production_vmware_insecure.zip
-unzip coreos_production_vmware_insecure.zip
+unzip coreos_production_vmware_insecure.zip -d coreos_production_vmware_insecure
 cd coreos_production_vmware_insecure
 open coreos_production_vmware_insecure.vmx
 ```


### PR DESCRIPTION
wget is not installed by default on OS X, so use curl instead
