### PR TITLE
fix clone URL

### DIFF
--- a/running-coreos/platforms/vagrant/index.md
+++ b/running-coreos/platforms/vagrant/index.md
@@ -32,7 +32,7 @@ will download the image and start it for you.
 
 
 ```
-git clone https://github.com/coreos/coreos-vagrant/
+git clone https://github.com/coreos/coreos-vagrant.git
 cd coreos-vagrant
 ```
 


### PR DESCRIPTION
Using previous docs:

```
$ git clone https://github.com/coreos/coreos-vagrant/
Cloning into 'coreos-vagrant'...
ERROR: Repository not found.
fatal: Could not read from remote repository.
```
