### PR TITLE
etcdctl delete was changed to etcdctl rm, reflecting this in the docs

### DIFF
--- a/launching-containers/launching/getting-started-with-systemd/index.md
+++ b/launching-containers/launching/getting-started-with-systemd/index.md
@@ -100,7 +100,7 @@ After=docker.service
 ExecStart=/bin/bash -c '/usr/bin/docker start -a apache || /usr/bin/docker run -name apache -p 80:80 coreos/apache /usr/sbin/apache2ctl -D FOREGROUND'
 ExecStartPost=/usr/bin/etcdctl set /domains/example.com/10.10.10.123:8081 running
 ExecStop=/usr/bin/docker stop apache
-ExecStopPost=/usr/bin/etcdctl delete /domains/example.com/10.10.10.123:8081
+ExecStopPost=/usr/bin/etcdctl rm /domains/example.com/10.10.10.123:8081
 
 [Install]
 WantedBy=local.target


### PR DESCRIPTION
Had the chance this weekend to checkout CoreOS, going through docs, running examples, etc. It seems etcdctl delete was removed in 0.3 in favour of rm, docs should reflect that:)
