### PR TITLE
updating eth0 -> ens3 to match current release

### DIFF
--- a/running-coreos/platforms/libvirt/index.md
+++ b/running-coreos/platforms/libvirt/index.md
@@ -99,7 +99,7 @@ Now create the metadata directory and import the XML as new VM into your libvirt
 ### Network configuration
 
 By default, CoreOS uses DHCP to get its network configuration, but in my
-libvirt setup, I connect the VMs with a bridge to eth0.
+libvirt setup, I connect the VMs with a bridge to ens3.
 
 To make CoreOS use custom networking settings, you can mount the image’s OEM
 partition and add a run.sh shell script:
@@ -112,9 +112,9 @@ partition and add a run.sh shell script:
     #!/bin/bash
     systemctl disable dhcpcd.service
     systemctl stop dhcpcd.service
-    ip -4 address flush dev eth0
-    ip -4 address add 203.0.113.2/24 dev eth0
-    ip -4 link set dev eth0 up
+    ip -4 address flush dev ens3
+    ip -4 address add 203.0.113.2/24 dev ens3
+    ip -4 link set dev ens3 up
     ip -4 route add default via 203.0.113.1
     echo nameserver 8.8.8.8 > /etc/resolv.conf
     EOT

--- a/sdk-distributors/distributors/notes-for-distributors/index.md
+++ b/sdk-distributors/distributors/notes-for-distributors/index.md
@@ -76,9 +76,9 @@ The simplest way to handle setup is to create a `run` that does everything you n
 
 systemctl disable dhcpcd.service
 systemctl stop dhcpcd.service
-ip -4 address flush dev eth0
-ip -4 address add xxx.xxx.xxx.xxx/xx dev eth0
-ip -4 link set dev eth0 up
+ip -4 address flush dev ens3
+ip -4 address add xxx.xxx.xxx.xxx/xx dev ens3
+ip -4 link set dev ens3 up
 ip -4 route add default via xxx.xxx.xxx.xxx
 echo nameserver 8.8.8.8 > /etc/resolv.conf
 


### PR DESCRIPTION
booting the latest release I see the message "systemd-udevd[291]: renamed network interface eth0 to ens3"

this breaks custom OEM networking based on eth0
