### PR TITLE
fix(platforms): point to usr images

### DIFF
--- a/running-coreos/platforms/eucalyptus/index.md
+++ b/running-coreos/platforms/eucalyptus/index.md
@@ -17,7 +17,7 @@ These steps will download the CoreOS image, uncompress it, convert it from qcow-
 In order to convert the image you will need to install ```qemu-img``` with your favorite package manager.
 
 ```
-$ wget -q http://storage.core-os.net/coreos/amd64-generic/dev-channel/coreos_production_openstack_image.img.bz2
+$ wget -q http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_openstack_image.img.bz2
 $ bunzip2 coreos_production_openstack_image.img.bz2
 $ qemu-img convert -O raw coreos_production_openstack_image.img coreos_production_openstack_image.raw
 $ euca-bundle-image -i coreos_production_openstack_image.raw -r x86_64 -d /var/tmp

--- a/running-coreos/platforms/libvirt/index.md
+++ b/running-coreos/platforms/libvirt/index.md
@@ -26,7 +26,7 @@ We start by downloading the most recent disk image:
 
     mkdir -p /usr/src/dock0
     cd /usr/src/dock0
-    wget http://storage.core-os.net/coreos/amd64-generic/dev-channel/coreos_production_qemu_image.img.bz2
+    wget http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_qemu_image.img.bz2
     bunzip2 coreos_production_qemu_image.img.bz2
 
 ## Virtual machine configuration

--- a/running-coreos/platforms/qemu/index.md
+++ b/running-coreos/platforms/qemu/index.md
@@ -73,8 +73,8 @@ image. There are two files you need: the disk image (provided in qcow2
 format) and the wrapper shell script to start QEMU.
 
     mkdir coreos; cd coreos
-    wget http://storage.core-os.net/coreos/amd64-generic/dev-channel/coreos_production_qemu.sh
-    wget http://storage.core-os.net/coreos/amd64-generic/dev-channel/coreos_production_qemu_image.img.bz2 -O - | bzcat > coreos_production_qemu_image.img
+    wget http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_qemu.sh
+    wget http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_qemu_image.img.bz2 -O - | bzcat > coreos_production_qemu_image.img
     chmod +x coreos_production_qemu.sh
 
 Starting is as simple as:

--- a/running-coreos/platforms/vmware/index.md
+++ b/running-coreos/platforms/vmware/index.md
@@ -21,7 +21,7 @@ you will need to launch the `coreos_developer_vmware_insecure.vmx` file to creat
 This is a rough sketch that should work on OSX and Linux:
 
 ```
-curl -O http://storage.core-os.net/coreos/amd64-generic/dev-channel/coreos_production_vmware_insecure.zip
+curl -O http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_vmware_insecure.zip
 unzip coreos_production_vmware_insecure.zip -d coreos_production_vmware_insecure
 cd coreos_production_vmware_insecure
 open coreos_production_vmware_insecure.vmx


### PR DESCRIPTION
Point all non-PXE platforms at usr images. These platforms still need cloud-config support.
