### PR TITLE
fix(*): Document using gpg detached signatures instead of DIGESTS

### DIFF
--- a/running-coreos/bare-metal/booting-with-pxe/index.md
+++ b/running-coreos/bare-metal/booting-with-pxe/index.md
@@ -71,13 +71,16 @@ You can view all of the [cloud-config options here]({{site.url}}/docs/cluster-ma
 
 In the config above you can see that a Kernel image and a initramfs file is needed.
 Download these two files into your tftp root.
-The extra `coreos_production_pxe.DIGESTS.asc` file can be used to [verify the others][verify-notes].
+The extra `coreos_production_pxe.vmlinuz.sig` and `coreos_production_pxe_image.cpio.gz.sig` files can be used to [verify the downloaded files][verify-notes].
 
 ```
 cd /var/lib/tftpboot
 wget http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_pxe.vmlinuz
+wget http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_pxe.vmlinuz.sig
 wget http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_pxe_image.cpio.gz
-wget http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_pxe.DIGESTS.asc
+wget http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_pxe_image.cpio.gz.sig
+gpg --verify coreos_production_pxe.vmlinuz.sig
+gpg --verify coreos_production_pxe_image.cpio.gz.sig
 ```
 
 PXE booted machines cannot currently update themselves.

--- a/sdk-distributors/distributors/notes-for-distributors/index.md
+++ b/sdk-distributors/distributors/notes-for-distributors/index.md
@@ -14,12 +14,11 @@ Images of CoreOS are hosted at `http://storage.core-os.net/coreos/amd64-usr/`. A
 
 If you are importing images for use inside of your environment it is recommended that you import from a URL in the following format `http://storage.core-os.net/coreos/amd64-usr/${CHANNEL}/`. For example to grab the alpha OpenStack version of CoreOS you can import `http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_openstack_image.img.bz2`. There is a `version.txt` file in this directory which you can use to label the image with a version number as well.
 
-It is recommended that you also verify files using the [CoreOS Image Signing Key][signing-key]. The digests are simply the image URL, replacing `_image.img.bz2` with `.DIGESTS.asc`. You can verify the digest with `gpg --verify` after importing the signing key. Then the image itself can be verified based on one of the hashes in `.DIGESTS.asc`. For example:
+It is recommended that you also verify files using the [CoreOS Image Signing Key][signing-key]. The GPG signature for each image is a detached `.sig` file that must be passed to `gpg --verify`. For example:
 
     wget http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_openstack_image.img.bz2
-    wget http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_openstack.DIGESTS.asc
-    gpg --verify coreos_production_openstack.DIGESTS.asc
-    sha512sum -c coreos_production_openstack.DIGESTS.asc
+    wget http://storage.core-os.net/coreos/amd64-usr/alpha/coreos_production_openstack_image.img.bz2.sig
+    gpg --verify coreos_production_openstack_image.img.bz2.sig
 
 [signing-key]: {{site.url}}/security/image-signing-key
 


### PR DESCRIPTION
As of release 298 we generate .sig files which are much easier to deal
with than the oddball DIGESTS format.
