### PR TITLE
Add an example binding docker to localhost port

### DIFF
--- a/launching-containers/building/customizing-docker/index.md
+++ b/launching-containers/building/customizing-docker/index.md
@@ -73,6 +73,7 @@ coreos:
 To keep access to the port local, replace the `ListenStream` configuration above with:
 
 ```
+        [Socket]
         ListenStream=127.0.0.1:4243
 ```
 


### PR DESCRIPTION
Add an example of binding the port to localhost to prevent external access
