### PR TITLE
Rename docker ephemeral .mount unit

### DIFF
--- a/cluster-management/setup/mounting-storage/index.md
+++ b/cluster-management/setup/mounting-storage/index.md
@@ -48,7 +48,7 @@ coreos:
         RemainAfterExit=yes
         ExecStart=/usr/sbin/wipefs -f /dev/xvdb
         ExecStart=/usr/sbin/mkfs.btrfs -f /dev/xvdb
-    - name: media-ephemeral.mount
+    - name: var-lib-docker.mount
       command: start
       content: |
         [Unit]


### PR DESCRIPTION
I got an error when using this example. It didn't match the conventions for matching the mount unit name to `Where`, so this changed seemed to help.
