### PR TITLE
fix(mounting-storage): run mount unit after formatting unit

### DIFF
--- a/cluster-management/setup/mounting-storage/index.md
+++ b/cluster-management/setup/mounting-storage/index.md
@@ -54,6 +54,7 @@ coreos:
         [Unit]
         Description=Mount ephemeral to /var/lib/docker
         Requires=format-ephemeral.service
+        After=format-ephemeral.service
         Before=docker.service
         [Mount]
         What=/dev/xvdb


### PR DESCRIPTION
Regarding website I Wish on /docs/cluster-management/setup/mounting-storage/

"I wish this page var-lib-docker.mount needs After=format-ephemeral.service, not just Requires="
