### PR TITLE
Remove deprecated -name option for docker

### DIFF
--- a/launching-containers/launching/launching-containers-fleet/index.md
+++ b/launching-containers/launching/launching-containers-fleet/index.md
@@ -66,7 +66,7 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-ExecStart=/usr/bin/docker run -rm -name apache -p 80:80 coreos/apache /usr/sbin/apache2ctl -D FOREGROUND
+ExecStart=/usr/bin/docker run -rm --name apache -p 80:80 coreos/apache /usr/sbin/apache2ctl -D FOREGROUND
 ExecStop=/usr/bin/docker rm -f apache
 
 [X-Fleet]


### PR DESCRIPTION
Change the deprecated option "-name" to "--name" for docker, to avoid warning:

```
Warning: '-name' is deprecated, it will be replaced by '--name' soon. See usage.
```
