### PR TITLE
OpenStack should be camelcased

### DIFF
--- a/running-coreos/cloud-providers/rackspace/index.md
+++ b/running-coreos/cloud-providers/rackspace/index.md
@@ -9,7 +9,7 @@ weight: 5
 
 # Running CoreOS on Rackspace
 
-CoreOS is currently in heavy development and actively being tested.  These instructions will walk you through running CoreOS on the Rackspace Openstack cloud, which differs slightly from the generic Openstack instructions. There are two ways to launch a CoreOS cluster: launch an entire cluster with Heat or launch machines with Nova.
+CoreOS is currently in heavy development and actively being tested.  These instructions will walk you through running CoreOS on the Rackspace OpenStack cloud, which differs slightly from the generic OpenStack instructions. There are two ways to launch a CoreOS cluster: launch an entire cluster with Heat or launch machines with Nova.
 
 
 ## Choosing a Channel

--- a/running-coreos/platforms/openstack/index.md
+++ b/running-coreos/platforms/openstack/index.md
@@ -57,13 +57,13 @@ $ glance image-create --name CoreOS \
 ## Cloud-Config
 
 CoreOS allows you to configure machine parameters, launch systemd units on startup and more via cloud-config. Jump over to the [docs to learn about the supported features][cloud-config].
-We're going to provide our cloud-config to Openstack via the user-data flag. Our cloud-config will also contain SSH keys that will be used to connect to the instance.
+We're going to provide our cloud-config to OpenStack via the user-data flag. Our cloud-config will also contain SSH keys that will be used to connect to the instance.
 In order for this to work your OpenStack cloud provider must support [config drive][config-drive] or the OpenStack metadata service.
 
 [cloud-config]: {{site.url}}/docs/cluster-management/setup/cloudinit-cloud-config
 [config-drive]: http://docs.openstack.org/user-guide/content/config-drive.html
 
-The most common cloud-config for Openstack looks like:
+The most common cloud-config for OpenStack looks like:
 
 ```yaml
 #cloud-config

--- a/running-coreos/platforms/vmware/index.md
+++ b/running-coreos/platforms/vmware/index.md
@@ -70,7 +70,7 @@ The last step uploads the files to your ESXi datastore and registers your VM. Yo
 
 Cloud-config can be specified by attaching a [config-drive]({{site.url}}/docs/cluster-management/setup/cloudinit-config-drive/) with the label `config-2`. This is commonly done through whatever interface allows for attaching cd-roms or new drives.
 
-Note that the config-drive standard was originally an Openstack feature, which is why you'll see strings containing `openstack`. This filepath needs to be retained, although CoreOS supports config-drive on all platforms.
+Note that the config-drive standard was originally an OpenStack feature, which is why you'll see strings containing `openstack`. This filepath needs to be retained, although CoreOS supports config-drive on all platforms.
 
 For more information on customization that can be done with cloud-config, head on over to the [cloud-config guide]({{site.url}}/docs/cluster-management/setup/cloudinit-cloud-config/).
 


### PR DESCRIPTION
Fix a number of references to "Openstack" that should be "OpenStack".
