### PR TITLE
fleetctl load hello.service before fleetctl start

### DIFF
--- a/quickstart/index.md
+++ b/quickstart/index.md
@@ -132,6 +132,7 @@ Then load and start the unit:
 
 ```sh
 $ fleetctl load hello.service
+Job hello.service loaded on c72c6ea2.../10.65.174.36
 $ fleetctl start hello.service
 Job hello.service launched on 8145ebb7.../172.17.8.105
 ```


### PR DESCRIPTION
`fleetctl` can't start a service until it has been loaded. Normally, this would go without saying. But since this is the quickstart guide, let's be explicit.
