### PR TITLE
Fix syntax error in docker run command

### DIFF
--- a/launching-containers/launching/launching-containers-fleet/index.md
+++ b/launching-containers/launching/launching-containers-fleet/index.md
@@ -30,7 +30,7 @@ TimeoutStartSec=0
 ExecStartPre=-/usr/bin/docker kill busybox1
 ExecStartPre=-/usr/bin/docker rm busybox1
 ExecStartPre=/usr/bin/docker pull busybox
-ExecStart=/usr/bin/docker run busybox --name busybox1 /bin/sh -c "while true; do echo Hello World; sleep 1; done"
+ExecStart=/usr/bin/docker run --name busybox1 busybox /bin/sh -c "while true; do echo Hello World; sleep 1; done"
 ```
 
 Run the start command to start up the container on the cluster:


### PR DESCRIPTION
The given 'docker run' command has wrong syntax. If you specify image as first parameter after 'run' the --name parameter is taken as command to execute, which obviously failed.
