### PR TITLE
launching-containers: warn about detached mode

### DIFF
--- a/launching-containers/building/getting-started-with-docker/index.md
+++ b/launching-containers/building/getting-started-with-docker/index.md
@@ -67,11 +67,13 @@ docker run [options] coreos/apache [process]
 
 ### Run Container Detached
 
-The most important option is to run the container in detached mode with the `-d` flag. This will output the container ID to show that the command was successful, but nothing else. At any time you can run `docker ps` in the other shell to view a list of the running containers. Our command now looks like:
+When running docker containers manually, the most important option is to run the container in detached mode with the `-d` flag. This will output the container ID to show that the command was successful, but nothing else. At any time you can run `docker ps` in the other shell to view a list of the running containers. Our command now looks like:
 
 ```sh
 docker run -d coreos/apache [process]
 ```
+
+After you are comfortable with the mechanics of running containers by hand, it's recommeneded to use [systemd units]({{site.url}}/docs/launching-containers/launching/getting-started-with-systemd) and/or [fleet]({{site.url}}/docs/launching-containers/launching/launching-containers-fleet) to run your containers on a cluster of CoreOS machines.
 
 ### Run Apache in Foreground
 

--- a/launching-containers/launching/getting-started-with-systemd/index.md
+++ b/launching-containers/launching/getting-started-with-systemd/index.md
@@ -44,7 +44,7 @@ The description shows up in the systemd log and a few other places. Write someth
 
 `After=docker.service` and `Requires=docker.service` means this unit will only start after `docker.service` is active. You can define as many of these as you want.
 
-`ExecStart=` allows you to specify any command that you'd like to run when this unit is started.
+`ExecStart=` allows you to specify any command that you'd like to run when this unit is started. The pid assigned to this process is what systemd will monitor to determine whether the process has crashed or not. Do not run docker containers with `-d` as this will prevent the container from starting as a child of this pid. systemd will think the process has exited and the unit will be stopped.
 
 `WantedBy=` is the target that this unit is a part of.
 

--- a/launching-containers/launching/launching-containers-fleet/index.md
+++ b/launching-containers/launching/launching-containers-fleet/index.md
@@ -34,6 +34,8 @@ ExecStart=/usr/bin/docker run --name busybox1 busybox /bin/sh -c "while true; do
 ExecStop=/usr/bin/docker stop busybox1
 ```
 
+If you've been running docker commands manually, be sure you don't copy a `docker run` command that starts a container in detached mode (`-d`). Detached mode won't start the container as a child of the unit's pid. This will cause the unit to run for just a few seconds and then exit.
+
 Run the start command to start up the container on the cluster:
 
 ```sh


### PR DESCRIPTION
It's really easy for users to copy and paste a command that works manually in detached mode into a unit that won't play nice with systemd.
