### PR TITLE
escape JSON in DigitalOcean curl example

### DIFF
--- a/running-coreos/cloud-providers/digitalocean/index.md
+++ b/running-coreos/cloud-providers/digitalocean/index.md
@@ -145,7 +145,7 @@ curl --request POST "https://api.digitalocean.com/v2/droplets" \
       "name":"core-1",
       "private_networking":true,
       "ssh_keys":['$SSH_KEY_ID'],
-      "user_data": "'"$(cat cloud-config.yaml)"'"
+      "user_data": "'"$(cat cloud-config.yaml | sed 's/"/\\"/g')"'"
 }'
 
 ```


### PR DESCRIPTION
Fixes invalid JSON error for cloud configs that contain double quotes.
