### PR TITLE
quickstart: use public/private IP for peering and client communication

### DIFF
--- a/quickstart/index.md
+++ b/quickstart/index.md
@@ -58,6 +58,8 @@ coreos:
   etcd:
     name: coreos0
     discovery: https://discovery.etcd.io/<token>
+    addr: $public_ipv4:4001
+    peer-addr: $private_ipv4:7001
 ```
 
 In order to get the discovery token, visit [https://discovery.etcd.io/new] and you will receive a URL including your token. Paste the whole thing into your cloud-config file.


### PR DESCRIPTION
Without this change, etcd will advertise 127.0.0.1 instead. Clustering
won't work as expected. If the user setups more than one CoreOS host,
etcd won't work on the other hosts.
