### PR TITLE
Adding `apt-get update` before installing apache2

### DIFF
--- a/launching-containers/building/getting-started-with-docker/index.md
+++ b/launching-containers/building/getting-started-with-docker/index.md
@@ -31,7 +31,7 @@ Let's launch an Ubuntu container and install Apache inside of it using the bash 
 docker run -t -i ubuntu /bin/bash
 ```
 
-The `-t` and `-i` flags allocate a pseudo-tty and keep stdin open even if not attached. This will allow you to use the container like a traditional VM as long as the bash prompt is running. Install Apache with `apt-get install apache2`. You're probably wondering what address you can connect to in order to test that Apache was correctly installed...we'll get to that after we commit the container.
+The `-t` and `-i` flags allocate a pseudo-tty and keep stdin open even if not attached. This will allow you to use the container like a traditional VM as long as the bash prompt is running. Install Apache with `apt-get update && apt-get install apache2`. You're probably wondering what address you can connect to in order to test that Apache was correctly installed...we'll get to that after we commit the container.
 
 ## Commiting a Container
 


### PR DESCRIPTION
After pulling and starting the ubuntu container, running `apt-get install apache` won't cut it, because `apt-get update` needs to be run first.
