### PR TITLE
feat(getting-started-with-etcd) simplify getting docker0 interface programmatically

### DIFF
--- a/distributed-configuration/getting-started-with-etcd/index.md
+++ b/distributed-configuration/getting-started-with-etcd/index.md
@@ -71,7 +71,7 @@ $ curl -L http://172.17.42.1:4001/v2/keys/
 You can also fetch the `docker0` IP programmatically:
 
 ```
-ETCD_ENDPOINT="$(ifconfig docker0 | grep 'inet ' | awk '{ print $2}'):4001"
+ETCD_ENDPOINT="$(ifconfig docker0 | awk '/\<inet\>/ { print $2}'):4001"
 ```
 
 ## Proxy Example


### PR DESCRIPTION
grep followed by awk or sed can be simplified to remove the grep. Also made it search for inet as a single word to avoid getting inet6 where ipv6 is enabled on the interface.
