### PR TITLE
digitalocean: add ssh instructions

### DIFF
--- a/running-coreos/cloud-providers/digitalocean/index.md
+++ b/running-coreos/cloud-providers/digitalocean/index.md
@@ -126,6 +126,18 @@ populated, the droplet must have private networking enabled.
 To add more instances to the cluster, just launch more with the same
 cloud-config. New instances will join the cluster regardless of region.
 
+## SSH to your Droplets
+
+CoreOS is set up to be a little more secure than other DigitalOcean images. By default, it uses the core user instead of root and doesn't use a password for authentication. You'll need to add an SSH key(s) via the web console or add keys/passwords via your cloud-config in order to log in.
+
+To connect to a droplet after it's created, run:
+
+```sh
+ssh core@<ip address>
+```
+
+Optionally, you may want to [configure your ssh-agent]({{site.url}}/docs/launching-containers/launching/fleet-using-the-client/#remote-fleet-access) to more easily run [fleet commands]({{site.url}}/docs/launching-containers/launching/launching-containers-fleet/).
+
 ## Launching Droplets
 
 ### Via the API


### PR DESCRIPTION
Addresses part of https://twitter.com/shimetweets/status/526336370277892096

> @digitalocean fix the credentials you send in the email for coreos instances. default user is not root, but 'core'. spent hours on this

We can't change their emails, but hopefully this lets people know they can safely ignore them. Also adds a note to optionally set up an ssh-agent for a better fleet experience.
