### PR TITLE
Add a link to /releases/

### DIFF
--- a/running-coreos/bare-metal/booting-with-pxe/index.md
+++ b/running-coreos/bare-metal/booting-with-pxe/index.md
@@ -74,7 +74,7 @@ Note: The `$private_ipv4` and `$public_ipv4` substitution variables referenced i
 
 ### Choose a Channel
 
-CoreOS is released into alpha and beta channels. Releases to each channel serve as a release-candidate for the next channel. For example, a bug-free alpha release is promoted bit-for-bit to the beta channel.
+CoreOS is [released]({{site.url}}/releases/) into alpha and beta channels. Releases to each channel serve as a release-candidate for the next channel. For example, a bug-free alpha release is promoted bit-for-bit to the beta channel.
 
 PXE booted machines cannot currently update themselves when new versions are released to a channel. To update to the latest version of CoreOS download/verify these files again and reboot.
 


### PR DESCRIPTION
I'm new to CoreOS and had to go fishing around to find the /releases/ page to find out what alpha/beta mean to CoreOS. This adds a link so it's easy to find in context.
