### PR TITLE
add superuser feature flag to example config.yaml

### DIFF
--- a/enterprise-registry/initial-setup/index.md
+++ b/enterprise-registry/initial-setup/index.md
@@ -92,6 +92,7 @@ USER_EVENTS_REDIS: {'host': '(FILL IN HERE: redis host)'}
 
 # The usernames of your super-users, if any. Super users will
 # have the ability to view and delete other users.
+FEATURE_SUPER_USERS: false
 SUPER_USERS: []
 
 # Either 'Database' or 'LDAP'.


### PR DESCRIPTION
Someone came on IRC and couldn't find the superuser menu. We discovered it was missing from the docs.
