### PR TITLE
Add comment for auth-less mailserver.

### DIFF
--- a/enterprise-registry/initial-setup/index.md
+++ b/enterprise-registry/initial-setup/index.md
@@ -66,7 +66,8 @@ SERVER_HOSTNAME: '(FILL IN HERE: registry.mycorp.com)'
 ENTERPRISE_LOGO_URL: '(FILL IN HERE: http://someurl/...)'
 
 # Settings for SMTP and mailing. This is *required*. Note: "localhost" will not work since the
-# registry is run inside a container.
+# registry is run inside a container. Delete or use null values for username and password if
+# you are running an auth-less mailserver.
 MAIL_PORT: 587
 MAIL_PASSWORD: '(FILL IN HERE: password)'
 MAIL_SERVER: '(FILL IN HERE: hostname)'


### PR DESCRIPTION
As with my previous PR, we have had customers ask about how to configure the registry for using a mail server that does not have any authentication (because it is behind a corporate firewall).
