### PR TITLE
enterprise-registry: fix formatting and other nits

### DIFF
--- a/enterprise-registry/initial-setup/index.md
+++ b/enterprise-registry/initial-setup/index.md
@@ -19,17 +19,21 @@ CoreOS Enterprise Registry requires five components to operate successfully:
 
 ## Preparing the Database
 
-A MySQL RDBMS or Postgres installation with an empty database is required, and a login with full access to said database. The schema will be created the first time the registry image is run. The database install can either be pre-existing or run on CoreOS via a Docker container.
+A MySQL RDBMS or Postgres installation with an empty database is required, and a login with full access to said database. The schema will be created the first time the registry image is run. The database install can either be pre-existing or run on CoreOS via a [Docker container]({{site.url}}/docs/enterprise-registry/mysql-container).
 
 Please have the url for the login and database available in the SQLAlchemy format:
 
 ### For MySQL:
-```mysql+pymysql://<username>:<url escaped password>@<hostname>/<database_name>```
+
+```
+mysql+pymysql://<username>:<url escaped password>@<hostname>/<database_name>
+```
 
 ### For Postgres:
-```postgresql://<username>:<url escaped password>@<hostname>/<database_name>```
 
-If you don't have an existing MySQL system to host the Enterprise Registry database on then you can run the steps in the [Using a dedicated MySQL Docker container]({{site.url}}/docs/enterprise-registry/mysql-container) document.
+```
+postgresql://<username>:<url escaped password>@<hostname>/<database_name>
+```
 
 ## Setting up Redis
 

--- a/enterprise-registry/log-debugging/index.md
+++ b/enterprise-registry/log-debugging/index.md
@@ -1,26 +1,29 @@
 ---
 layout: docs
-title: LDAP debugging
+title: Enterprise Registry Log debugging
 category: registry
-forkurl: https://github.com/coreos/docs/blob/master/enterprise-registry/ldap-logging/index.md
 weight: 5
 ---
 
-# Enterprise Registry log debugging
+# Enterprise Registry Log Debugging
+
 To aid in debugging issues such as LDAP configuration you can tail the logs of the Enterprise Registry container from the Docker host as shown below:
 
-```shell
+```sh
 CONTAINER_ID=$(docker ps | grep "coreos/registry:latest" | awk '{print $1}')
 LOG_LOCATION=$(docker inspect -f '{{ index .Volumes "/var/log" }}' ${CONTAINER_ID})
 tail -f  ${LOG_LOCATION}/gunicorn_web/* ${LOG_LOCATION}/gunicorn_registry/* ${LOG_LOCATION}/gunicorn_verbs/*
 ```
 
 Alternatively you can download a simple shell script to perform the steps above:
-```shell
-curl --location {{site.url}}/docs/enterprise-registry/ldap-logging/tail_gunicorn_logs.sh -o /tmp/tail_gunicorn_logs.sh -#
+
+```sh
+curl --location https://github.com/coreos/docs/blob/master/enterprise-registry/log-debugging/tail_gunicorn_logs.sh -o /tmp/tail_gunicorn_logs.sh -#
 ```
+
 Then run:
-```shell
+
+```sh
 chmod -c +x /tmp/tail_gunicorn_logs.sh
 /tmp/tail_gunicorn_logs.sh
 ```

--- a/enterprise-registry/mysql-container/index.md
+++ b/enterprise-registry/mysql-container/index.md
@@ -1,26 +1,36 @@
-### Using a dedicated MySQL Docker container
-If you don't have an existing MySQL system to host the Enterprise Registry database on then you can run the steps below to create a dedicated MySQL container using the Oracle MySQL verified Docker image from: https://registry.hub.docker.com/_/mysql/
-```shell
-docker \
-  pull \
-  mysql:5.6;
+---
+layout: docs
+title: Setting Up a MySQL Docker Container
+category: registry
+weight: 5
+---
+
+# Setting Up a MySQL Docker Container
+
+If you don't have an existing MySQL system to host the Enterprise Registry database on then you can run the steps below to create a dedicated MySQL container using the Oracle MySQL verified Docker image from https://registry.hub.docker.com/_/mysql/
+
+```sh
+docker pull mysql:5.6
 ```
 
 Edit these values to your liking:
-```shell
+
+```sh
 MYSQL_USER="coreosuser"
 MYSQL_DATABASE="enterpriseregistrydb"
 MYSQL_CONTAINER_NAME="mysql"
 ```
 Do not edit these values:
 (creates a 32 char password for the MySQL root user and the Enterprise Registery DB user)
-```shell
+
+```sh
 MYSQL_ROOT_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | sed 1q)
 MYSQL_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | sed 1q)
 ```
 
 Start the MySQL container and create a new DB for the Enterprise registry:
-```shell
+
+```sh
 docker \
   run \
   --detach \
@@ -32,19 +42,23 @@ docker \
   --publish 3306:3306 \
   mysql:5.6;
 ```
+
 Wait about 30 seconds for the new DB to be created before testing the connection to the DB, the MySQL container will not respond during the initial DB creation process.
 
 Run the following command to output the DB URI for the MySQL database:
-```shell
+
+```sh
 echo "DB_URI: 'mysql+pymysql://${MYSQL_USER}:${MYSQL_PASSWORD}@db/${MYSQL_DATABASE}'"
 ```
 
 Alternatively you can download a simple shell script to perform the steps above:
-```shell
-curl --location {{site.url}}/docs/enterprise-registry/mysql-container/provision_mysql.sh -o /tmp/provision_mysql.sh -#
+
+```sh
+curl --location https://raw.githubusercontent.com/coreos/docs/master/enterprise-registry/mysql-container/provision_mysql.sh -o /tmp/provision_mysql.sh -#
 ```
 Then run:
-```shell
+
+```sh
 chmod -c +x /tmp/provision_mysql.sh
 /tmp/provision_mysql.sh
 ```


### PR DESCRIPTION
Notes for the future:
1. serving the shell scripts directly off GitHub instead of coreos.com as a security precaution.
2. our lexer for shell scripts uses `sh` not `shell`. Page builds will fail otherwise.
