### PR TITLE
launching-containers: move registry auth to separate doc

### DIFF
--- a/launching-containers/building/customizing-docker/index.md
+++ b/launching-containers/building/customizing-docker/index.md
@@ -230,55 +230,6 @@ coreos:
 
 ## Using a dockercfg File for Authentication
 
-A json file `.dockercfg` can be created in your home directory that holds authentication information for a public or private docker registry. The auth token is a base64 encoded string: `base64(<username>:<password>)`. Here's what an example looks like with credentials for docker's public index and a private index:
+A json file `.dockercfg` can be created in your home directory that holds authentication information for a public or private docker registry.
 
-```json
-{
-  "https://index.docker.io/v1/": {
-    "auth": "xXxXxXxXxXx=",
-    "email": "username@example.com"
-  },
-  "https://index.example.com": {
-    "auth": "XxXxXxXxXxX=",
-    "email": "username@example.com"
-  }
-}
-```
-
-The last step is to tell your systemd units to run as the core user in order for docker to use the credentials we just set up. This is done in the service section of the unit:
-
-```ini
-[Unit]
-Description=My Container
-After=docker.service
-
-[Service]
-User=core
-ExecStart=/usr/bin/docker run busybox /bin/sh -c "while true; do echo Hello World; sleep 1; done"
-
-[Install]
-WantedBy=multi-user.target
-```
-
-### Cloud-Config
-
-Since each machine in your cluster is going to have to pull images, cloud-config is the easiest way to write the config file to disk.
-
-```yaml
-#cloud-config
-write_files:
-    - path: /home/core/.dockercfg
-      owner: core:core
-      permissions: 0644
-      content: |
-        {
-          "https://index.docker.io/v1/": {
-            "auth": "xXxXxXxXxXx=",
-            "email": "username@example.com"
-          },
-          "https://index.example.com": {
-            "auth": "XxXxXxXxXxX=",
-            "email": "username@example.com"
-          }
-        }
-```
+Read more about [registry authentication]({{site.url}}/docs/launching-containers/building/registry-authentication).

--- a/launching-containers/building/registry-authentication/index.md
+++ b/launching-containers/building/registry-authentication/index.md
@@ -1,0 +1,85 @@
+---
+layout: docs
+title: Using Authentication for a Registry
+category: launching_containers
+sub_category: building
+weight: 7
+---
+
+# Using Authentication for a Registry
+
+A json file `.dockercfg` can be created in your home directory that holds authentication information for a public or private docker registry. The auth token is a base64 encoded string: `base64(<username>:<password>)`.
+
+## The .dockercfg File
+
+Here's what an example looks like with credentials for docker's public index and a private index:
+
+
+#### .dockercfg
+
+```json
+{
+  "https://index.docker.io/v1/": {
+    "auth": "xXxXxXxXxXx=",
+    "email": "username@example.com"
+  },
+  "https://index.example.com": {
+    "auth": "XxXxXxXxXxX=",
+    "email": "username@example.com"
+  }
+}
+```
+
+The last step is to tell your systemd units to run as the `core` user in order for docker to use the credentials we just set up. This is done in the service section of the unit:
+
+```ini
+[Unit]
+Description=My Container
+After=docker.service
+
+[Service]
+User=core
+ExecStart=/usr/bin/docker run busybox /bin/sh -c "while true; do echo Hello World; sleep 1; done"
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Cloud-Config
+
+Since each machine in your cluster is going to have to pull images, cloud-config is the easiest way to write the config file to disk.
+
+```yaml
+#cloud-config
+write_files:
+    - path: /home/core/.dockercfg
+      owner: core:core
+      permissions: 0644
+      content: |
+        {
+          "https://index.docker.io/v1/": {
+            "auth": "xXxXxXxXxXx=",
+            "email": "username@example.com"
+          },
+          "https://index.example.com": {
+            "auth": "XxXxXxXxXxX=",
+            "email": "username@example.com"
+          }
+        }
+```
+
+## Using a Registry Without SSL Configured
+
+The default behavior of Docker is to prevent access to registries that aren't using SSL. If you're running a registry behind your firewall without SSL, you need to configure an additional parameter, which whitelists a CIDR range of allowed "insecure" registries.
+
+The best way to do this is within your cloud-config:
+
+```yaml
+#cloud-config
+
+write_files:
+  - path: /etc/systemd/system/docker.service.d/50-insecure-registry.conf
+    content: |
+        [Service]
+        Environment=DOCKER_OPTS='--insecure-registry="10.0.1.0/24"'
+```


### PR DESCRIPTION
Added info about configuring insecure registries and I figured it was enough for its own doc. Probably easier to find too. I kept a link at the old location to this new one.

cc: @crawford
