### PR TITLE
cluster-management: configure fleetctl on worker machines

### DIFF
--- a/cluster-management/setup/cluster-architectures/index.md
+++ b/cluster-management/setup/cluster-architectures/index.md
@@ -132,6 +132,14 @@ coreos:
   units:
     - name: fleet.service
       command: start
+write_files:
+  - path: /etc/profile.d/fleetctl.sh
+    permissions: 0644
+    owner: core
+    content: |
+      # configure fleetctl to work with our etcd servers set above
+      export FLEETCTL_ENDPOINT=/var/run/fleet.sock
+      export FLEETCTL_EXPERIMENTAL_API=true
 ```
 
 ## Production Cluster with Central Services
@@ -214,4 +222,12 @@ coreos:
     # CoreUpdate group ID for "Production Workers"
     group: f118a298-2a8a-460b-9edd-3a9b49df504e
     server: https://customer.update.core-os.net/v1/update/
+write_files:
+  - path: /etc/profile.d/fleetctl.sh
+    permissions: 0644
+    owner: core
+    content: |
+      # configure fleetctl to work with our etcd servers set above
+      export FLEETCTL_ENDPOINT=/var/run/fleet.sock
+      export FLEETCTL_EXPERIMENTAL_API=true
 ```


### PR DESCRIPTION
Fixes a UX issue where the entire system is configured properly, but `fleetctl` worked differently depending on which machine you were connected to.

cc: @bcwaldon 
