### PR TITLE
Explain why docker run --rm isn't used for ExecStart.

### DIFF
--- a/launching-containers/launching/getting-started-with-systemd/index.md
+++ b/launching-containers/launching/getting-started-with-systemd/index.md
@@ -117,6 +117,8 @@ ExecStopPost=/usr/bin/etcdctl rm /domains/example.com/10.10.10.123:8081
 WantedBy=multi-user.target
 ```
 
+While it's possible to manage the starting, stopping, and removal of the container in a single `ExecStart` command by using `docker run --rm`, it's a good idea to separate the container's lifecycle into `ExecStartPre`, `ExecStart`, and `ExecStop` options as we've done above. This gives you a chance to inspect the container's state after it stops or fails.
+
 ## Unit Specifiers
 
 In our last example we had to hardcode our IP address when we announced our container in etcd. That's not scalable and systemd has a few variables built in to help us out. Here's a few of the most useful:


### PR DESCRIPTION
A small addition to explain why separate `ExecStartPre`, `ExecStart`, and `ExecStop` options are preferred to a single `ExecStart` using `docker run --rm`.

Closes #418.