### PR TITLE
running-coreos: update install script options

### DIFF
--- a/running-coreos/bare-metal/installing-to-disk/index.md
+++ b/running-coreos/bare-metal/installing-to-disk/index.md
@@ -61,6 +61,8 @@ For reference here are the rest of the `coreos-install` options:
 -o OEM      OEM type to install (e.g. openstack)
 -c CLOUD    Insert a cloud-init config to be executed on boot.
 -t TMPDIR   Temporary location with enough space to download images.
+-v          Super verbose, for debugging.
+-b BASEURL  URL to the image mirror
 ```
 
 ## Cloud Config


### PR DESCRIPTION
Added missing params `-b` and `-v`

cc: @marineam