### PR TITLE
Add FreeBind=true to sshd.socket example

### DIFF
--- a/cluster-management/setup/customizing-sshd/index.md
+++ b/cluster-management/setup/customizing-sshd/index.md
@@ -49,6 +49,7 @@ coreos:
       [Socket]
       ListenStream=2222
       Accept=yes
+      FreeBind=true
 ```
 
 ## Further Reading


### PR DESCRIPTION
Update recommendation as per https://github.com/coreos/bugs/issues/57#issuecomment-55455975 otherwise the socket will fail to start if the network isn't up yet. On my test hosts this happens regularly, which requires a machine reboot to try the race again :)