### PR TITLE
PR for updating cluster-management/setup/update-strategies/index.md. See issue #428

### DIFF
--- a/cluster-management/setup/update-strategies/index.md
+++ b/cluster-management/setup/update-strategies/index.md
@@ -125,10 +125,7 @@ ExecStart=/usr/bin/bash /opt/bin/update-window.sh
 Description=Reboot timer
 
 [Timer]
-OnCalendar=*-*-* 05,06:10/20:00
-
-[Install]
-WantedBy=timers.target
+OnCalendar=*-*-* 05,06:00/30:00
 ```
 More [information on systemd timers](http://www.freedesktop.org/software/systemd/man/systemd.timer.html) and the available ways you can configure your maintenance window.
 
@@ -139,12 +136,9 @@ This script should be installed in a location to match the script path used in t
 ```yaml
 #!/bin/bash
 
-# Randomly delay reboot between 0 and 3600 seconds.
-# If etcd is not running, simply reboot, otherwise use locksmithctl reboot to get reboot lock.
+# If etcd is active, this uses locksmith. Otherwise, it randomly delays. 
 delay=$(/usr/bin/expr $RANDOM % 3600 )
 rebootflag='NEED_REBOOT'
-# For testing force reboot, uncomment the following line
-#rebootflag='VERSION'
 
 if update_engine_client -status | grep $rebootflag;
 then

--- a/cluster-management/setup/update-strategies/index.md
+++ b/cluster-management/setup/update-strategies/index.md
@@ -187,12 +187,9 @@ write_files:
   - path: /opt/bin/update-window.sh
     content: |
         #!/bin/bash
-        # Randomly delay reboot between 0 and 3600 seconds.
-        # If etcd is not running, simply reboot, otherwise use locksmithctl reboot to get reboot lock.
+        # If etcd is active, this uses locksmith. Otherwise, it randomly delays. 
         delay=$(/usr/bin/expr $RANDOM % 3600 )
         rebootflag='NEED_REBOOT'
-        # For testing force reboot, uncomment the following line
-        #rebootflag='VERSION'
 
         if update_engine_client -status | grep $rebootflag;
         then

--- a/cluster-management/setup/update-strategies/index.md
+++ b/cluster-management/setup/update-strategies/index.md
@@ -178,10 +178,10 @@ coreos:
       command: start
       content: |
         [Unit]
-        Description=Reboot if needed at 05:10,05:30,05:50, and 06:10,06:30,06:50.
+        Description=Reboot timer
 
         [Timer]
-        OnCalendar=*-*-* 05,06:10/20:00
+        OnCalendar=*-*-* 05,06:00/30:00
         
 write_files:
   - path: /opt/bin/update-window.sh

--- a/cluster-management/setup/update-strategies/index.md
+++ b/cluster-management/setup/update-strategies/index.md
@@ -104,7 +104,7 @@ coreos:
 
 ## Auto-Updates with a Maintenance Window
 
-In this example, auto-reboot strategy is turned off so we can schedule it in a maintencence window in which a script checks if an update has been downloaded. If a reboot is needed and etcd service is running on the system, then call locksmithctl reboot to get a lock and reboot; otherwise, run a simple reboot after a random delay between 0 and 3600 seconds to prevent workers from rebooting at the same time. 
+In this example, auto-reboot strategy is turned off so we can schedule it in a maintencence window in which a script checks if an update has been downloaded. If a reboot is needed and etcd service is running on the system, then call locksmithctl reboot to get a lock and reboot; otherwise, run a simple reboot after a random delay to prevent workers from rebooting at the same time. 
 
 A timeframe in which to update can be specified by using two systemd units, a very simple service and a timer to run it on your schedule:
 
@@ -115,7 +115,7 @@ A timeframe in which to update can be specified by using two systemd units, a ve
 Description=Reboot if an update has been downloaded
 
 [Service]
-ExecStart=/usr/bin/bash /opt/bin/update-window.sh
+ExecStart=/opt/bin/update-window.sh
 ```
 
 #### update-window.timer
@@ -172,7 +172,7 @@ coreos:
         Description=Reboot if an update has been downloaded
 
         [Service]
-        ExecStart=/usr/bin/bash /opt/bin/update-window.sh 
+        ExecStart=/opt/bin/update-window.sh 
     - name: update-window.timer
       runtime: true
       command: start
@@ -185,6 +185,8 @@ coreos:
         
 write_files:
   - path: /opt/bin/update-window.sh
+    permissions: 0755
+    owner: root
     content: |
         #!/bin/bash
         # If etcd is active, this uses locksmith. Otherwise, it randomly delays. 


### PR DESCRIPTION
Use a script in maintenance window for reboot update. If etcd is running, use locksmith reboot and retry every 20 minutes starting 5:10 a.m. every 20 minutes until 6:50 a.m. to avoid missing update window. If etcd is not running, simply reboot after a random delay.