### PR TITLE
Update FLEETCTL_ENDPOINT syntax for unix sockets

### DIFF
--- a/cluster-management/setup/cluster-architectures/index.md
+++ b/cluster-management/setup/cluster-architectures/index.md
@@ -156,7 +156,7 @@ write_files:
     owner: core
     content: |
       # configure fleetctl to work with our etcd servers set above
-      export FLEETCTL_ENDPOINT=/var/run/fleet.sock
+      export FLEETCTL_ENDPOINT=unix:///var/run/fleet.sock
       export FLEETCTL_EXPERIMENTAL_API=true
 ```
 
@@ -252,6 +252,6 @@ write_files:
     owner: core
     content: |
       # configure fleetctl to work with our etcd servers set above
-      export FLEETCTL_ENDPOINT=/var/run/fleet.sock
+      export FLEETCTL_ENDPOINT=unix:///var/run/fleet.sock
       export FLEETCTL_EXPERIMENTAL_API=true
 ```


### PR DESCRIPTION
This syntax was changed in `fleet` 0.9.0 - unix socket paths must now be prepended with `file://`, or else they don't work.