### PR TITLE
Fix example command in debugging tools docs

### DIFF
--- a/cluster-management/debugging/install-debugging-tools/index.md
+++ b/cluster-management/debugging/install-debugging-tools/index.md
@@ -46,7 +46,7 @@ Pulling repository index.example.com/debug
 Advanced users can SSH directly into a toolbox by setting up an `/etc/passwd` entry:
 
 ```sh
-useradd bob -m -p '*' -s /usr/bin/toolbox -g sudo -G docker
+useradd bob -m -p '*' -s /usr/bin/toolbox -U -G sudo,docker
 ```
 
 To test, SSH as bob:

--- a/cluster-management/debugging/install-debugging-tools/index.md
+++ b/cluster-management/debugging/install-debugging-tools/index.md
@@ -46,7 +46,7 @@ Pulling repository index.example.com/debug
 Advanced users can SSH directly into a toolbox by setting up an `/etc/passwd` entry:
 
 ```sh
-useradd bob -m -p '*' -s /usr/bin/toolbox
+useradd bob -m -p '*' -s /usr/bin/toolbox -g sudo -G docker
 ```
 
 To test, SSH as bob:


### PR DESCRIPTION
In order for a user to use toolbox they need to be in the sudo and docker group.
See [toolbox#Advanced Usage](https://github.com/coreos/toolbox#advanced-usage) for inspiration.