### PR TITLE
running-coreos: use standard channel tabs on Openstack

### DIFF
--- a/running-coreos/platforms/openstack/index.md
+++ b/running-coreos/platforms/openstack/index.md
@@ -18,15 +18,44 @@ it with the `glance` tool and running your first cluster with the `nova` tool.
 These steps will download the CoreOS image, uncompress it and then import it
 into the glance image store.
 
-### Choosing a Channel
+## Choosing a Channel
 
-CoreOS is released into alpha and beta channels. Releases to each channel serve as a release-candidate for the next channel. For example, a bug-free alpha release is promoted bit-for-bit to the beta channel.
+CoreOS is designed to be [updated automatically]({{site.url}}/using-coreos/updates) with different schedules per channel. You can [disable this feature]({{site.url}}/docs/cluster-management/debugging/prevent-reboot-after-update), although we don't recommend it. Read the [release notes]({{site.url}}/releases) for specific features and bug fixes.
 
-The channel is selected based on the URL below. Simply replace `alpha` with `beta`. Read the [release notes]({{site.url}}/releases) for specific features and bug fixes in each channel.
-
-```sh
+<div id="openstack-create">
+  <ul class="nav nav-tabs">
+    <li class="active"><a href="#stable-create" data-toggle="tab">Stable Channel</a></li>
+    <li><a href="#beta-create" data-toggle="tab">Beta Channel</a></li>
+    <li><a href="#alpha-create" data-toggle="tab">Alpha Channel</a></li>
+  </ul>
+  <div class="tab-content coreos-docs-image-table">
+    <div class="tab-pane" id="alpha-create">
+      <p>The alpha channel closely tracks master and is released to frequently. The newest versions of <a href="{{site.url}}/using-coreos/docker">docker</a>, <a href="{{site.url}}/using-coreos/etcd">etcd</a> and <a href="{{site.url}}/using-coreos/clustering">fleet</a> will be available for testing. Current version is CoreOS {{site.alpha-channel}}.</p>
+<pre>
 $ wget http://alpha.release.core-os.net/amd64-usr/current/coreos_production_openstack_image.img.bz2
 $ bunzip2 coreos_production_openstack_image.img.bz2
+</pre>
+    </div>
+    <div class="tab-pane" id="beta-create">
+      <p>The beta channel consists of promoted alpha releases. Current version is CoreOS {{site.beta-channel}}.</p>
+<pre>
+$ wget http://beta.release.core-os.net/amd64-usr/current/coreos_production_openstack_image.img.bz2
+$ bunzip2 coreos_production_openstack_image.img.bz2
+</pre>
+    </div>
+  <div class="tab-pane active" id="stable-create">
+      <p>The Stable channel should be used by production clusters. Versions of CoreOS are battle-tested within the Beta and Alpha channels before being promoted. Current version is CoreOS {{site.stable-channel}}.</p>
+<pre>
+$ wget http://stable.release.core-os.net/amd64-usr/current/coreos_production_openstack_image.img.bz2
+$ bunzip2 coreos_production_openstack_image.img.bz2
+</pre>
+    </div>
+  </div>
+</div>
+
+Once the download completes, add the CoreOS image into Glance:
+
+```sh
 $ glance image-create --name CoreOS \
   --container-format bare \
   --disk-format qcow2 \


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/755540/6333968/3dfa439c-bb46-11e4-8ca7-8c55156cb67b.png)
