### PR TITLE
Update Vultr documentation.

### DIFF
--- a/running-coreos/cloud-providers/vultr/index.md
+++ b/running-coreos/cloud-providers/vultr/index.md
@@ -19,6 +19,8 @@ The simplest option to boot up CoreOS is to select the "CoreOS Stable" operating
 
 First, you'll need to make a shell script containing your `cloud-config` available at a public URL:
 
+**cloud-config-bootstrap.sh**
+
 ```sh
 #!/bin/bash
 

--- a/running-coreos/cloud-providers/vultr/index.md
+++ b/running-coreos/cloud-providers/vultr/index.md
@@ -34,8 +34,6 @@ Please be sure to check out [Using Cloud-Config]({{site.url}}/docs/cluster-manag
 
 You must add to your ssh public key to your `cloud-config`'s [ssh authorized keys]({{site.url}}/docs/cluster-management/setup/cloudinit-cloud-config/#ssh_authorized_keys) so you'll be able to log in.
 
-Note that the `$private_ipv4` and `$public_ipv4` variables are only supported on Vultr if you have the 'cloud-config-url' option set on your kernel command line. Without this option, you will need to hard code these values into your `cloud-config` file.
-
 ## Choosing a Channel
 
 CoreOS is designed to be [updated automatically]({{site.url}}/using-coreos/updates) with different schedules per channel. You can [disable this feature]({{site.url}}/docs/cluster-management/debugging/prevent-reboot-after-update), although we don't recommend it. Read the [release notes]({{site.url}}/releases) for specific features and bug fixes.

--- a/running-coreos/cloud-providers/vultr/index.md
+++ b/running-coreos/cloud-providers/vultr/index.md
@@ -15,17 +15,20 @@ These instructions will walk you through running a single CoreOS node. This guid
 
 The simplest option to boot up CoreOS is to select the "CoreOS Stable" operating system from Vultr's default offerings. However, most deployments require a custom `cloud-config`, which can only be achieved in Vultr with an iPXE script. The remainder of this article describes this process.
 
-First, you'll need to make two files available at public URL's -- your `cloud-config` file and the following shell script *(be sure to replace the cloud-config URL)*:
+## Cloud-Config
+
+First, you'll need to make two files available at public URL's -- your `cloud-config` file and the following shell script:
 
 ```sh
 #!/bin/bash
 
-curl -o cloud-config.yaml URL_TO_YOUR_CLOUD_CONFIG
+# Location of your valid cloud-config file.
+URL = "http://example.com/cloud-config.yaml"
+
+curl -o cloud-config.yaml $URL
 sudo coreos-install -d /dev/vda -c cloud-config.yaml
 sudo reboot
 ```
-
-## Cloud-Config
 
 Please be sure to check out [Using Cloud-Config]({{site.url}}/docs/cluster-management/setup/cloudinit-cloud-config).
 
@@ -52,8 +55,11 @@ CoreOS is designed to be [updated automatically]({{site.url}}/using-coreos/updat
 
 <pre>#!ipxe
 
+# Location of your shell script.
+set cloud-config-url http://example.com/cloud-config-bootstrap.sh
+
 set base-url http://alpha.release.core-os.net/amd64-usr/current
-kernel ${base-url}/coreos_production_pxe.vmlinuz cloud-config-url=URL_TO_YOUR_SHELL_SCRIPT
+kernel ${base-url}/coreos_production_pxe.vmlinuz cloud-config-url=${cloud-config-url}
 initrd ${base-url}/coreos_production_pxe_image.cpio.gz
 boot</pre>
     </div>
@@ -65,8 +71,11 @@ boot</pre>
 
 <pre>#!ipxe
 
+# Location of your shell script.
+set cloud-config-url http://example.com/cloud-config-bootstrap.sh
+
 set base-url http://beta.release.core-os.net/amd64-usr/current
-kernel ${base-url}/coreos_production_pxe.vmlinuz cloud-config-url=URL_TO_YOUR_SHELL_SCRIPT
+kernel ${base-url}/coreos_production_pxe.vmlinuz cloud-config-url=${cloud-config-url}
 initrd ${base-url}/coreos_production_pxe_image.cpio.gz
 boot</pre>
     </div>
@@ -78,8 +87,11 @@ boot</pre>
 
 <pre>#!ipxe
 
+# Location of your shell script.
+set cloud-config-url http://example.com/cloud-config-bootstrap.sh
+
 set base-url http://stable.release.core-os.net/amd64-usr/current
-kernel ${base-url}/coreos_production_pxe.vmlinuz cloud-config-url=URL_TO_YOUR_SHELL_SCRIPT
+kernel ${base-url}/coreos_production_pxe.vmlinuz cloud-config-url=${cloud-config-url}
 initrd ${base-url}/coreos_production_pxe_image.cpio.gz
 boot</pre>
     </div>

--- a/running-coreos/cloud-providers/vultr/index.md
+++ b/running-coreos/cloud-providers/vultr/index.md
@@ -17,17 +17,17 @@ The simplest option to boot up CoreOS is to select the "CoreOS Stable" operating
 
 ## Cloud-Config
 
-First, you'll need to make two files available at public URL's -- your `cloud-config` file and the following shell script:
+First, you'll need to make two files available at public URL's -- your `cloud-config` file and a shell script which you need to create:
 
 ```sh
+URL="http://example.com/cloud-config.yaml"
+
+cat << EOF > ./cloud-config-bootstrap.sh\n
 #!/bin/bash
-
-# Location of your valid cloud-config file.
-URL = "http://example.com/cloud-config.yaml"
-
 curl -o cloud-config.yaml $URL
 sudo coreos-install -d /dev/vda -c cloud-config.yaml
 sudo reboot
+EOF
 ```
 
 Please be sure to check out [Using Cloud-Config]({{site.url}}/docs/cluster-management/setup/cloudinit-cloud-config).

--- a/running-coreos/cloud-providers/vultr/index.md
+++ b/running-coreos/cloud-providers/vultr/index.md
@@ -17,17 +17,20 @@ The simplest option to boot up CoreOS is to select the "CoreOS Stable" operating
 
 ## Cloud-Config
 
-First, you'll need to make two files available at public URL's -- your `cloud-config` file and a shell script which you need to create:
+First, you'll need to make a shell script containing your `cloud-config` available at a public URL:
 
 ```sh
-URL="http://example.com/cloud-config.yaml"
-
-cat << EOF > ./cloud-config-bootstrap.sh\n
 #!/bin/bash
-curl -o cloud-config.yaml $URL
+
+cat "cloud-config.yaml" <<EOF
+#cloud-config
+
+ssh_authorized_keys:
+  - ssh-rsa ...
+EOF
+
 sudo coreos-install -d /dev/vda -c cloud-config.yaml
 sudo reboot
-EOF
 ```
 
 Please be sure to check out [Using Cloud-Config]({{site.url}}/docs/cluster-management/setup/cloudinit-cloud-config).


### PR DESCRIPTION
1. **Install to disk rather than RAM.** The Vultr page currently explains how to install to RAM, which I believe is unique among the "cloud provider" pages. I can't imagine why one would do this on a cloud server. I can only assume it was done that way because it was the simplest possible installation at the time, but Vultr now provides their own CoreOS image so that is no longer the case.

2. **Use custom `cloud-config`.** Now that Vultr provides a CoreOS image, the only use case for a custom iso is to provide a custom `cloud-config`.

3. **Use Vultr's "Startup Scripts" feature to provide the iPXE.** This feature has been added since the docs and makes the process a lot simpler.

4. **Moved "Cloud Config" above "Choosing a Channel".** You need to know the url to your `cloud-config` before you can write the pxe file.

5. **SSH public key in `cloud-config` rather than pxe.** I actually am not sure if this is necessary, but it works and strikes me as more appropriate.

6. **Remove screenshot.** Screenshot is quite dated. Neither the CoreOS "Operating System" option or the "Startup Scripts" features existed when it was taken. I'd be willing to add an updated screenshot if eye candy is mandatory.

I believe all the other changes are self-explanatory updates.

I think this should close #341.