### PR TITLE
Update running-coreos/platforms/vmware/index.md

### DIFF
--- a/running-coreos/platforms/vmware/index.md
+++ b/running-coreos/platforms/vmware/index.md
@@ -35,7 +35,7 @@ open coreos_production_vmware_insecure.vmx
 
 ### To deploy on an ESXi/vSphere host, convert the VM to OVF
 * follow the steps above to download and extract the coreos_production_vmware_insecure.zip
-* download and run the [OVF Tool 3.5.0 installer](https://developercenter.vmware.com/tool/ovf/3.5.0) Requires VMware account login but the download is free. Available for Linux, OSX & Windows for both 32 & 64 bit architectures.
+* download and run the [OVF Tool installer](https://developercenter.vmware.com/tool/ovf/) Requires VMware account login but the download is free. Available for Linux, OSX & Windows for both 32 & 64 bit architectures.
 * convert VM to OVF from the extract dir
 
 ```sh


### PR DESCRIPTION
[Documentation update]
The old link (https://developercenter.vmware.com/tool/ovf/3.5.0) pointed to a 404, changing to the tool's generic homepage (https://developercenter.vmware.com/tool/ovf/) which looks exactly the same as the previous link, but doesn't need to be updated every time VMWare pushs an update.