### PR TITLE
Moved quote in Environment specification

### DIFF
--- a/launching-containers/building/registry-authentication/index.md
+++ b/launching-containers/building/registry-authentication/index.md
@@ -81,5 +81,5 @@ write_files:
   - path: /etc/systemd/system/docker.service.d/50-insecure-registry.conf
     content: |
         [Service]
-        Environment=DOCKER_OPTS='--insecure-registry="10.0.1.0/24"'
+        Environment='DOCKER_OPTS=--insecure-registry="10.0.1.0/24"'
 ```


### PR DESCRIPTION
Got stung by this when trying to add more than one parameter here. See
https://github.com/coreos/coreos-overlay/issues/1052