### PR TITLE
added locksmith directive to example cloud-config

### DIFF
--- a/cluster-management/setup/cluster-architectures/index.md
+++ b/cluster-management/setup/cluster-architectures/index.md
@@ -237,10 +237,10 @@ coreos:
   locksmith:
     endpoint: "http://10.0.0.101:4001,http://10.0.0.102:4001,http://10.0.0.103:4001,http://10.0.0.104:4001,http://10.0.0.105:4001"
   units:
+    - name: etcd.service
+      mask: true
     - name: fleet.service
       command: start
-    - name: etcd.service
-      command: stop
   update:
     # CoreUpdate group ID for "Production Workers"
     group: f118a298-2a8a-460b-9edd-3a9b49df504e

--- a/cluster-management/setup/cluster-architectures/index.md
+++ b/cluster-management/setup/cluster-architectures/index.md
@@ -234,9 +234,13 @@ coreos:
   fleet:
     metadata: "role=worker,cabinet=two,disk=spinning"
     etcd_servers: "http://10.0.0.101:4001,http://10.0.0.102:4001,http://10.0.0.103:4001,http://10.0.0.104:4001,http://10.0.0.105:4001"
+  locksmith:
+    endpoint: "http://10.0.0.101:4001,http://10.0.0.102:4001,http://10.0.0.103:4001,http://10.0.0.104:4001,http://10.0.0.105:4001"
   units:
     - name: fleet.service
       command: start
+    - name: etcd.service
+      command: stop
   update:
     # CoreUpdate group ID for "Production Workers"
     group: f118a298-2a8a-460b-9edd-3a9b49df504e


### PR DESCRIPTION
If you leave locksmith alone, and leave etcd running then your reboot-strategy gets all out of sync due to locksmith only talking to local etcd