### PR TITLE
fix typo in curl command

### DIFF
--- a/cluster-management/setup/cluster-discovery/index.md
+++ b/cluster-management/setup/cluster-discovery/index.md
@@ -16,7 +16,7 @@ CoreOS uses etcd, a service running on each machine, to handle coordination betw
 A discovery service, [https://discovery.etcd.io](https://discovery.etcd.io), is provided as a free service to help connect etcd instances together by storing a list of peer addresses, metadata and the initial size of the cluster under a unique address, known as the discovery URL. You can generate them very easily:
 
 ```
-$ curl -w "\n" https://discovery.etcd.io/new?size=3
+$ curl -w "\n" 'https://discovery.etcd.io/new?size=3'
 https://discovery.etcd.io/6a28e078895c5ec737174db2419bb2f3
 ```
 


### PR DESCRIPTION
The unquoted/unescaped question mark breaks this command. Not sure if you guys prefer escaping or quoting, but I chose quoting.