### PR TITLE
Fix typo in initial size comment

### DIFF
--- a/quickstart/index.md
+++ b/quickstart/index.md
@@ -63,7 +63,7 @@ coreos:
   etcd:
     name: coreos0
     # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
-    # specify the intial size of your cluster with ?size=X
+    # specify the initial size of your cluster with ?size=X
     discovery: https://discovery.etcd.io/<token>
 ```
 


### PR DESCRIPTION
Fixes typo in the initial size comment when discussing the etcd discovery URL.