### PR TITLE
Fix markdown

### DIFF
--- a/cluster-management/setup/flannel-config/index.md
+++ b/cluster-management/setup/flannel-config/index.md
@@ -94,6 +94,7 @@ coreos:
 This includes fleet.service as fleet daemon will start units that may run Docker containers.
 
 *Important*: If you are starting flannel on Vagrant, it should be instructed to use the correct network interface:
+
 ```yaml
 #cloud-config
 


### PR DESCRIPTION
Missing line break between embedded snipped and previous paragraph.  This is what this renders like outside of github:

![broken formatting] (http://i.imgur.com/NNhKTvz.png)