### PR TITLE
Hint metadata and global units can be combined

### DIFF
--- a/launching-containers/launching/launching-containers-fleet/index.md
+++ b/launching-containers/launching/launching-containers-fleet/index.md
@@ -294,6 +294,8 @@ MachineMetadata=platform=cloud
 MachineMetadata=region=east
 ```
 
+It's also possible to restrict a global unit by metadata, thus scheduling a unit on all machines matching some requirements.
+
 #### More Information
 <a class="btn btn-default" href="{{site.url}}/docs/launching-containers/launching/fleet-example-deployment">Example Deployment with fleet</a>
 <a class="btn btn-default" href="{{site.url}}/docs/launching-containers/launching/fleet-unit-files/">fleet Unit Specifications</a>


### PR DESCRIPTION
This never occurred to me after months of wondering about how I might schedule
units to take advantage of AWS auto-scaling. It's obvious in retrospect, but
there's a mental speed-bump: how can a unit be "global" if it runs only on some
subset, according to metadata? This hint should be sufficient to avoid that
mental block.
