### PR TITLE
Make networkd unit more permanent

### DIFF
--- a/cluster-management/setup/network-config-with-networkd/index.md
+++ b/cluster-management/setup/network-config-with-networkd/index.md
@@ -54,7 +54,6 @@ coreos:
     - name: fleet.service
       command: start
     - name: 00-eth0.network
-      runtime: true
       content: |
         [Match]
         Name=eth0


### PR DESCRIPTION
If you work from this example with `runtime: true`, the unit is created
under `/run`. Normally, this would be fine for most uses, but on Amazon
DHCP will configure both interfaces. To prevent this, the unit files
must be written permanently because DHCP runs before cloud-config.

Dropping `runtime: true` here will have no effect on most installs, but
will allow static routing and preventing asymmetric routes on Amazon.

I only changed one line. The ending was touched by GitHub's editor.