### PR TITLE
Correct env file name

### DIFF
--- a/cluster-management/setup/flannel-config/index.md
+++ b/cluster-management/setup/flannel-config/index.md
@@ -131,7 +131,7 @@ Here is the sequence of events that happens when `flanneld.service` is started f
 3. `flanneld.service` executes `DOCKER_HOST=unix:///var/run/early-docker.sock docker run --net=host quay.io/coreos/flannel:$FLANNEL_VER` (actual invocation is slightly more complex).
 4. flanneld starts and writes out `/run/flannel/subnet.env` with the acquired IP subnet information.
 5. `ExecStartPost` in `flanneld.service` converts information in `/run/flannel/subnet.env` into Docker daemon command line args (such as `--bip` and `--mtu`),
-storing them in `/run/docker_opts.env`
+storing them in `/run/flannel_docker_opts.env`
 6. `redis.service` gets started which invokes `docker run ...`, triggering socket activation of `docker.service`.
 7. `docker.service` sources in `/run/flannel_docker_opts.env` which contains env variables with command line options and starts the Docker with them.
 8. `redis.service` runs Docker redis container.


### PR DESCRIPTION
I believe Item 5 in the sequence of events in the flannel-config should be /run/flannel_docker_opts.env according to the flanneld.service file at https://github.com/coreos/coreos-overlay/blob/master/app-admin/flannel/files/flanneld.service and to match up with the filename in Item 7 in the same sequence.