### PR TITLE
Correct 'Ubuntu' to 'minimal busybox'

### DIFF
--- a/quickstart/index.md
+++ b/quickstart/index.md
@@ -91,7 +91,7 @@ If you followed a guide to set up more than one CoreOS machine, you can SSH into
 
 ## Container Management with docker
 
-The second building block, **docker** ([docs][docker-docs]), is where your applications and code run. It is installed on each CoreOS machine. You should make each of your services (web server, caching, database) into a container and connect them together by reading and writing to etcd. You can quickly try out a Ubuntu container in two different ways:
+The second building block, **docker** ([docs][docker-docs]), is where your applications and code run. It is installed on each CoreOS machine. You should make each of your services (web server, caching, database) into a container and connect them together by reading and writing to etcd. You can quickly try out a minimal busybox container in two different ways:
 
 Run a command in the container and then stop it: 
 


### PR DESCRIPTION
The busybox container in the examples is not an actual Ubuntu installation; this change updates the text to reflect this.