### PR TITLE
Fix race condition with device availability

### DIFF
--- a/cluster-management/setup/mounting-storage/index.md
+++ b/cluster-management/setup/mounting-storage/index.md
@@ -43,6 +43,8 @@ coreos:
       content: |
         [Unit]
         Description=Formats the ephemeral drive
+        After=dev-xvdb.device
+        Requires=dev-xvdb.device
         [Service]
         Type=oneshot
         RemainAfterExit=yes


### PR DESCRIPTION
Occasionally for some reason ephemeral block devices seem to take a little while to become available.

This fixes it.