### PR TITLE
Store ECS Agent state on the host

### DIFF
--- a/running-coreos/cloud-providers/ecs/index.md
+++ b/running-coreos/cloud-providers/ecs/index.md
@@ -43,7 +43,7 @@ coreos:
        ExecStartPre=-/usr/bin/docker kill ecs-agent
        ExecStartPre=-/usr/bin/docker rm ecs-agent
        ExecStartPre=/usr/bin/docker pull amazon/amazon-ecs-agent
-       ExecStart=/usr/bin/docker run --name ecs-agent --env=ECS_CLUSTER=${ECS_CLUSTER} --env=ECS_LOGLEVEL=${ECS_LOGLEVEL} --env=ECS_CHECKPOINT=${ECS_CHECKPOINT} --publish=127.0.0.1:51678:51678 --volume=/var/run/docker.sock:/var/run/docker.sock -v /home/core/ecs-data:/data amazon/amazon-ecs-agent
+       ExecStart=/usr/bin/docker run --name ecs-agent --env=ECS_CLUSTER=${ECS_CLUSTER} --env=ECS_LOGLEVEL=${ECS_LOGLEVEL} --env=ECS_CHECKPOINT=${ECS_CHECKPOINT} --publish=127.0.0.1:51678:51678 --volume=/var/run/docker.sock:/var/run/docker.sock --volume=/var/lib/aws/ecs:/data amazon/amazon-ecs-agent
        ExecStop=/usr/bin/docker stop ecs-agent
 ```
 

--- a/running-coreos/cloud-providers/ecs/index.md
+++ b/running-coreos/cloud-providers/ecs/index.md
@@ -39,10 +39,11 @@ coreos:
        [Service]
        Environment=ECS_CLUSTER=your_cluster_name
        Environment=ECS_LOGLEVEL=warn
+       Environment=ECS_CHECKPOINT=true
        ExecStartPre=-/usr/bin/docker kill ecs-agent
        ExecStartPre=-/usr/bin/docker rm ecs-agent
        ExecStartPre=/usr/bin/docker pull amazon/amazon-ecs-agent
-       ExecStart=/usr/bin/docker run --name ecs-agent --env=ECS_CLUSTER=${ECS_CLUSTER} --env=ECS_LOGLEVEL=${ECS_LOGLEVEL} --publish=127.0.0.1:51678:51678 --volume=/var/run/docker.sock:/var/run/docker.sock amazon/amazon-ecs-agent
+       ExecStart=/usr/bin/docker run --name ecs-agent --env=ECS_CLUSTER=${ECS_CLUSTER} --env=ECS_LOGLEVEL=${ECS_LOGLEVEL} --env=ECS_CHECKPOINT=${ECS_CHECKPOINT} --publish=127.0.0.1:51678:51678 --volume=/var/run/docker.sock:/var/run/docker.sock -v /home/core/ecs-data:/data amazon/amazon-ecs-agent
        ExecStop=/usr/bin/docker stop ecs-agent
 ```
 


### PR DESCRIPTION
Prevents the ECS Agent registering as a brand new container instance every time the agent or host is rebooted.