### PR TITLE
docs: only expose the new etcd server port

### DIFF
--- a/cluster-management/setup/cluster-discovery/index.md
+++ b/cluster-management/setup/cluster-discovery/index.md
@@ -34,11 +34,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd2.service
       command: start

--- a/running-coreos/cloud-providers/auro/index.md
+++ b/running-coreos/cloud-providers/auro/index.md
@@ -54,11 +54,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd2.service
       command: start

--- a/running-coreos/cloud-providers/azure/index.md
+++ b/running-coreos/cloud-providers/azure/index.md
@@ -75,11 +75,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd2.service
       command: start

--- a/running-coreos/cloud-providers/brightbox/index.md
+++ b/running-coreos/cloud-providers/brightbox/index.md
@@ -105,11 +105,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd2.service
       command: start

--- a/running-coreos/cloud-providers/digitalocean/index.md
+++ b/running-coreos/cloud-providers/digitalocean/index.md
@@ -107,11 +107,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd2.service
       command: start

--- a/running-coreos/cloud-providers/ec2/index.md
+++ b/running-coreos/cloud-providers/ec2/index.md
@@ -145,11 +145,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd2.service
       command: start

--- a/running-coreos/cloud-providers/exoscale/index.md
+++ b/running-coreos/cloud-providers/exoscale/index.md
@@ -72,11 +72,11 @@ coreos:
     # specify the initial size of your cluster with ?size=X
     discovery: https://discovery.etcd.io/<token>
     advertise-client-urls: http://$public_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$public_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$public_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$public_ipv4:2380,http://$public_ipv4:7001
+    listen-peer-urls: http://$public_ipv4:2380
 
   units:
     - name: etcd2.service

--- a/running-coreos/cloud-providers/google-compute-engine/index.md
+++ b/running-coreos/cloud-providers/google-compute-engine/index.md
@@ -34,11 +34,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd2.service
       command: start

--- a/running-coreos/cloud-providers/niftycloud/JA_JP/index.md
+++ b/running-coreos/cloud-providers/niftycloud/JA_JP/index.md
@@ -30,11 +30,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd.service
       command: start

--- a/running-coreos/cloud-providers/niftycloud/index.md
+++ b/running-coreos/cloud-providers/niftycloud/index.md
@@ -30,11 +30,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd.service
       command: start

--- a/running-coreos/cloud-providers/rackspace/index.md
+++ b/running-coreos/cloud-providers/rackspace/index.md
@@ -140,11 +140,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd.service
       command: start

--- a/running-coreos/cloud-providers/vexxhost/index.md
+++ b/running-coreos/cloud-providers/vexxhost/index.md
@@ -54,11 +54,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd.service
       command: start

--- a/running-coreos/platforms/openstack/index.md
+++ b/running-coreos/platforms/openstack/index.md
@@ -104,11 +104,11 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
     # multi-region and multi-cloud deployments need to use $public_ipv4
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
-    initial-advertise-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    initial-advertise-peer-urls: http://$private_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
   units:
     - name: etcd2.service
       command: start

--- a/running-coreos/platforms/vagrant/index.md
+++ b/running-coreos/platforms/vagrant/index.md
@@ -53,11 +53,11 @@ coreos:
     # WARNING: replace each time you 'vagrant destroy'
     discovery: https://discovery.etcd.io/<token>
     advertise-client-urls: http://$public_ipv4:2379,http://$public_ipv4:4001
-    initial-advertise-peer-urls: http://$public_ipv4:2380,http://$public_ipv4:7001
+    initial-advertise-peer-urls: http://$public_ipv4:2380
     # listen on both the official ports and the legacy ports
     # legacy ports can be omitted if your application doesn't depend on them
     listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    listen-peer-urls: http://$public_ipv4:2380,http://$public_ipv4:7001
+    listen-peer-urls: http://$public_ipv4:2380
   fleet:
       public-ip: $public_ipv4
   units:


### PR DESCRIPTION
It really only makes sense to expose the legacy client port since new
clusters will all use the new server port to communicate.