### PR TITLE
Refactor os/configuring-date-and-timezone.md to fix #533.

### DIFF
--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -169,9 +169,9 @@ coreos:
 ```
 
 
-## Switching between `systemd-timesyncd` and `ntpd`
+## Switching between `timesyncd` and `ntpd`
 
-On CoreOS 681.0.0 or later, you can switch from `timesyncd` back
+On CoreOS 681.0.0 or later, you can switch from `systemd-timesyncd` back
 to `ntpd` with the following commands:
 
 ```

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -27,7 +27,7 @@ NTP synchronized: yes
 
 ### Changing the timezone
 
-Start by listing the available time zones:
+Start by listing the available timezones:
 
 ```
 $ timedatectl list-timezones

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -39,7 +39,7 @@ $ sudo timedatectl set-timezone UTC
 ### Changing the time zone
 
 If your site or application requires a different system time zone, start by
-listing the available time zones:
+listing the available options:
 
 ```
 $ timedatectl list-timezones

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -7,7 +7,7 @@ requirements, explains the change in NTP client daemons in recent CoreOS
 versions, and offers advice on best practices for timekeeping in CoreOS
 clusters.
 
-## Viewing and changing date and time settings with `timedatectl`
+## Viewing and changing time and date with `timedatectl`
 
 The [`timedatectl(1)`][timedatectl] command displays and sets the time zone
 and current time.

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -91,8 +91,6 @@ coreos:
         Type=oneshot
 ```
 
-[timedatectl]: http://www.freedesktop.org/software/systemd/man/timedatectl.html
-
 
 ## Time synchronization
 
@@ -118,10 +116,6 @@ $ systemctl status systemd-timesyncd ntpd
    Loaded: loaded (/usr/lib64/systemd/system/ntpd.service; disabled; vendor preset: disabled)
    Active: inactive (dead)
 ```
-
-[681.0.0]: https://coreos.com/releases/#681.0.0
-[ntp.org]: http://ntp.org/
-[systemd-timesyncd]: http://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html
 
 ### Recommended NTP sources
 
@@ -167,9 +161,6 @@ coreos:
       [Time]
       NTP=0.pool.example.com 1.pool.example.com
 ```
-
-[systemd.network]: http://www.freedesktop.org/software/systemd/man/systemd.network.html
-[timesyncd.conf]: http://www.freedesktop.org/software/systemd/man/timesyncd.conf.html
 
 
 ## Switching between `systemd-timesyncd` and `ntpd`
@@ -235,3 +226,10 @@ coreos:
       restrict 127.0.0.1
       restrict [::1]
 ```
+
+[timedatectl]: http://www.freedesktop.org/software/systemd/man/timedatectl.html
+[681.0.0]: https://coreos.com/releases/#681.0.0
+[ntp.org]: http://ntp.org/
+[systemd-timesyncd]: http://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html
+[systemd.network]: http://www.freedesktop.org/software/systemd/man/systemd.network.html
+[timesyncd.conf]: http://www.freedesktop.org/software/systemd/man/timesyncd.conf.html

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -123,10 +123,10 @@ Unless you have a highly reliable and precise time server pool, use your cloud
 provider's NTP source, or, on bare metal, the default CoreOS NTP servers:
 
 ```
-server 0.coreos.pool.ntp.org
-server 1.coreos.pool.ntp.org
-server 2.coreos.pool.ntp.org
-server 3.coreos.pool.ntp.org
+0.coreos.pool.ntp.org
+1.coreos.pool.ntp.org
+2.coreos.pool.ntp.org
+3.coreos.pool.ntp.org
 ```
 
 ### Changing NTP time sources

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -126,10 +126,10 @@ $ systemctl status systemd-timesyncd ntpd
 [ntp.org]: http://ntp.org/
 [systemd-timesyncd]: http://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html
 
-### *CoreOS Recommends: CoreOS NTP pool*
+### *CoreOS Recommends: NTP sources*
 
-Unless you have a highly reliable and precise time server pool, use the default
-CoreOS NTP servers:
+Unless you have a highly reliable and precise time server pool, use your cloud
+provider's NTP source, or, on bare metal, the default CoreOS NTP servers:
 
 ```
 server 0.coreos.pool.ntp.org

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -1,10 +1,11 @@
 # Configuring Date and Time Zone
 
-By default, CoreOS machines keep time in the UTC time zone and synchronize
-their clocks with NTP. This page contains information about customizing
-those defaults to meet site requirements, explains the change in NTP client
-daemons in recent CoreOS versions, and offers advice on best practices for
-timekeeping in a CoreOS cluster.
+By default, CoreOS machines keep time in the Coordinated Universal Time (UTC)
+zone and synchronize their clocks with the Network Time Protocol (NTP).
+This page contains information about customizing those defaults to meet site
+requirements, explains the change in NTP client daemons in recent CoreOS
+versions, and offers advice on best practices for timekeeping in CoreOS
+clusters.
 
 ## Viewing and changing date and time settings with *timedatectl*
 
@@ -221,8 +222,8 @@ coreos:
 ### Time zone simplicity
 
 To avoid time zone confusion and the complexities of adjusting clocks for
-daylight saving time, we recommend that all machines in a CoreOS cluster use
-Coordinated Universal Time (UTC). This is the default.
+daylight saving time (or not) in accordance with regional custom, we recommend
+that all machines in CoreOS clusters use UTC. This is the default time zone.
 
 ```
 $ sudo timedatectl set-timezone UTC

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -2,17 +2,14 @@
 
 By default, CoreOS machines keep time in the Coordinated Universal Time (UTC)
 zone and synchronize their clocks with the Network Time Protocol (NTP).
-This page contains information about customizing those defaults to meet site
-requirements, explains the change in NTP client daemons in recent CoreOS
-versions, and offers advice on best practices for timekeeping in CoreOS
-clusters.
+This page contains information about customizing those defaults, explains
+the change in NTP client daemons in recent CoreOS versions, and offers advice
+on best practices for timekeeping in CoreOS clusters.
 
 ## Viewing and changing time and date with `timedatectl`
 
-The [`timedatectl(1)`][timedatectl] command displays and sets the time zone
-and current time.
-
-### Show the date, time, and time zone:
+The [`timedatectl(1)`][timedatectl] command displays and sets the date, time,
+and time zone.
 
 ```
 $ timedatectl status

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -209,6 +209,12 @@ restrict 127.0.0.1
 restrict [::1]
 ```
 
+Then reload the `ntpd` configuration:
+
+```
+$ sudo systemctl reload ntpd
+```
+
 Or, in cloud-config:
 
 ```yaml

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -6,7 +6,7 @@ This page contains information about customizing those defaults, explains
 the change in NTP client daemons in recent CoreOS versions, and offers advice
 on best practices for timekeeping in CoreOS clusters.
 
-## Viewing and changing time and date with `timedatectl`
+## Viewing and Changing Time and Date
 
 The [`timedatectl(1)`][timedatectl] command displays and sets the date, time,
 and time zone.
@@ -23,7 +23,7 @@ NTP synchronized: yes
       DST active: n/a
 ```
 
-### Recommended: UTC time
+### Recommended: UTC Time
 To avoid time zone confusion and the complexities of adjusting clocks for
 daylight saving time (or not) in accordance with regional custom, we recommend
 that all machines in CoreOS clusters use UTC. This is the default time zone. To
@@ -33,7 +33,7 @@ reset a machine to this default:
 $ sudo timedatectl set-timezone UTC
 ```
 
-### Changing the time zone
+### Changing the Time Zone
 
 If your site or application requires a different system time zone, start by
 listing the available options:
@@ -92,7 +92,7 @@ coreos:
 ```
 
 
-## Time synchronization
+## Time Synchronization
 
 CoreOS clusters use NTP to synchronize the clocks of member nodes, and all
 machines start an NTP client at boot. CoreOS versions later than
@@ -117,7 +117,7 @@ $ systemctl status systemd-timesyncd ntpd
    Active: inactive (dead)
 ```
 
-### Recommended NTP sources
+### Recommended NTP Sources
 
 Unless you have a highly reliable and precise time server pool, use your cloud
 provider's NTP source, or, on bare metal, the default CoreOS NTP servers:
@@ -129,7 +129,7 @@ provider's NTP source, or, on bare metal, the default CoreOS NTP servers:
 3.coreos.pool.ntp.org
 ```
 
-### Changing NTP time sources
+### Changing NTP Time Sources
 
 `Systemd-timesyncd` can discover NTP servers from DHCP, individual
 [network][systemd.network] configs, the file [`timesyncd.conf`][timesyncd.conf],
@@ -169,7 +169,7 @@ coreos:
 ```
 
 
-## Switching between `timesyncd` and `ntpd`
+## Switching from `timesyncd` to `ntpd`
 
 On CoreOS 681.0.0 or later, you can switch from `systemd-timesyncd` back
 to `ntpd` with the following commands:

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -1,6 +1,6 @@
-# Configuring Date and Timezone
+# Configuring Date and Time Zone
 
-By default, CoreOS machines keep time in the UTC timezone and synchronize
+By default, CoreOS machines keep time in the UTC time zone and synchronize
 their clocks with NTP. This page contains information about customizing
 those defaults to meet site requirements, explains the change in NTP client
 daemons in recent CoreOS versions, and offers advice on best practices for
@@ -8,7 +8,7 @@ timekeeping in a CoreOS cluster.
 
 ## Viewing and changing date and time settings with *timedatectl*
 
-The [*timedatectl*(1)][timedatectl] command displays and sets the timezone
+The [*timedatectl*(1)][timedatectl] command displays and sets the time zone
 and current time.
 
 ### Show the date, time, and zone:
@@ -25,9 +25,9 @@ NTP synchronized: yes
       DST active: n/a
 ```
 
-### Changing the timezone
+### Changing the time zone
 
-Start by listing the available timezones:
+Start by listing the available time zones:
 
 ```
 $ timedatectl list-timezones
@@ -37,7 +37,7 @@ Africa/Addis_Ababa
 …
 ```
 
-Pick a timezone from the list and set it:
+Pick a time zone from the list and set it:
 
 ```
 $ sudo timedatectl set-timezone America/New_York
@@ -63,7 +63,7 @@ NTP synchronized: yes
                   Sun 2014-11-02 01:00:00 EST
 ```
 
-Timezone may instead be set in cloud-config, with something like the following
+Time zone may instead be set in cloud-config, with something like the following
 excerpt:
 
 ```yaml
@@ -74,7 +74,7 @@ coreos:
       command: start
       content: |
         [Unit]
-        Description=Set the timezone
+        Description=Set the time zone
 
         [Service]
         ExecStart=/usr/bin/timedatectl set-timezone America/New_York
@@ -218,7 +218,7 @@ coreos:
 
 ## CoreOS Recommendations
 
-### What time zone should I use?
+### Time zone simplicity
 
 To avoid time zone confusion and the complexities of adjusting clocks for
 daylight saving time, we recommend that all machines in a CoreOS cluster use
@@ -228,7 +228,7 @@ Coordinated Universal Time (UTC). This is the default.
 $ sudo timedatectl set-timezone UTC
 ```
 
-### Which NTP servers should I sync against?
+### Which NTP servers should I synchronize with?
 
 Unless you have a highly reliable and precise time server pool, use the default
 CoreOS NTP servers:

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -1,13 +1,100 @@
 # Configuring Date and Timezone
 
-NTP is used to to keep clocks in sync across machines in a CoreOS cluster.
-CoreOS [681.0.0][681.0.0] uses [systemd-timesyncd][systemd-timesyncd] as the
-default NTP client, prior to that [ntpd][ntp.org] was used. Depending on the
-your version of CoreOS one of the two services will automatically start. To
-check which service is running, run the follow command:
+By default, CoreOS machines keep time in the UTC timezone and synchronize
+their clocks with NTP. This page contains information about customizing
+those defaults to meet site requirements, explains the change in NTP client
+daemons in recent CoreOS versions, and offers advice on best practices for
+timekeeping in a CoreOS cluster.
+
+## Viewing and changing date and time settings with *timedatectl*
+
+The [*timedatectl*(1)][timedatectl] command displays and sets the timezone
+and current time.
+
+### Show the date, time, and zone:
 
 ```
-sudo systemctl status systemd-timesyncd ntpd
+$ timedatectl status
+      Local time: Tue 2014-08-26 19:29:12 UTC
+  Universal time: Tue 2014-08-26 19:29:12 UTC
+        RTC time: Tue 2014-08-26 19:29:12
+       Time zone: UTC (UTC, +0000)
+     NTP enabled: no
+NTP synchronized: yes
+ RTC in local TZ: no
+      DST active: n/a
+```
+
+### Changing the timezone
+
+Start by listing the available time zones:
+
+```
+$ timedatectl list-timezones
+Africa/Abidjan
+Africa/Accra
+Africa/Addis_Ababa
+…
+```
+
+Pick a timezone from the list and set it:
+
+```
+$ sudo timedatectl set-timezone America/New_York
+```
+
+Check the changes:
+
+```
+$ timedatectl
+      Local time: Tue 2014-08-26 15:44:07 EDT
+  Universal time: Tue 2014-08-26 19:44:07 UTC
+        RTC time: Tue 2014-08-26 19:44:07
+       Time zone: America/New_York (EDT, -0400)
+     NTP enabled: no
+NTP synchronized: yes
+ RTC in local TZ: no
+      DST active: yes
+ Last DST change: DST began at
+                  Sun 2014-03-09 01:59:59 EST
+                  Sun 2014-03-09 03:00:00 EDT
+ Next DST change: DST ends (the clock jumps one hour backwards) at
+                  Sun 2014-11-02 01:59:59 EDT
+                  Sun 2014-11-02 01:00:00 EST
+```
+
+Timezone may instead be set in cloud-config, with something like the following
+excerpt:
+
+```yaml
+#cloud-config
+coreos:
+  units:
+    - name: settimezone.service
+      command: start
+      content: |
+        [Unit]
+        Description=Set the timezone
+
+        [Service]
+        ExecStart=/usr/bin/timedatectl set-timezone America/New_York
+        RemainAfterExit=yes
+        Type=oneshot
+```
+
+[timedatectl]: http://www.freedesktop.org/software/systemd/man/timedatectl.html
+
+
+## Time synchronization
+
+CoreOS clusters use NTP to synchronize the clocks of member nodes, and all
+machines start an NTP client at boot. CoreOS versions later than
+[681.0.0][681.0.0] use [*systemd-timesyncd*(8)][systemd-timesyncd] as the
+default NTP client. Earlier versions used [*ntpd*(8)][ntp.org]. To check which
+service is active, run the follow command:
+
+```
+$ sudo systemctl status systemd-timesyncd ntpd
 ● systemd-timesyncd.service - Network Time Synchronization
    Loaded: loaded (/usr/lib64/systemd/system/systemd-timesyncd.service; disabled; vendor preset: disabled)
    Active: active (running) since Thu 2015-05-14 05:43:20 UTC; 5 days ago
@@ -27,41 +114,14 @@ sudo systemctl status systemd-timesyncd ntpd
 [ntp.org]: http://ntp.org/
 [systemd-timesyncd]: http://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html
 
-## Switching between systemd-timesyncd and ntpd
+## Changing NTP time sources
 
-If you are on CoreOS 681.0.0 or later you can switch back to the classic ntpd
-with the following commands or cloud config:
+*Systemd-timesyncd* can discover NTP servers from DHCP, individual
+[network][systemd.network] configs, [timesyncd.conf][timesyncd.conf], or use
+the built-in `*.coreos.pool.ntp.org` pool.
 
-```
-sudo systemctl stop systemd-timesyncd
-sudo systemctl mask systemd-timesyncd
-sudo systemctl enable ntpd
-sudo systemctl start ntpd
-```
-
-```yaml
-#cloud-config
-
-coreos:
-  units:
-    - name: systemd-timesyncd.service
-      command: stop
-      mask: true
-    - name: ntpd.service
-      command: start
-      enable: true
-```
-
-It important to mask the service you do not want to start. The
-`systemctl disable` command will not override the system default to start.
-
-## Changing NTP time servers
-
-When using systemd-timesyncd NTP servers can be provided via DHCP, individual
-[network][systemd.network] configs, [timesyncd.conf][timesyncd.conf], or the
-built in default `*.coreos.pool.ntp.org` pool. For example, to disable the
-default behavior of using NTP servers from DHCP write the following to
-`/etc/systemd/network/50-dhcp-no-ntp.conf`:
+For example, to disable the default behavior of using NTP servers from DHCP,
+write the following to `/etc/systemd/network/50-dhcp-no-ntp.conf`:
 
 ```ini
 [Network]
@@ -74,12 +134,62 @@ UseDomains=true
 UseNTP=false
 ```
 
+The same can be accomplished with a snippet in cloud-config like:
+
+```yaml
+#cloud-config
+coreos:
+  write_files:
+  - path: /etc/systemd/timesyncd.conf
+    content: |
+      [Time]
+      NTP=0.pool.example.com 1.pool.example.com
+
+      [DHCP]
+      UseMTU=true
+      UseDomains=true
+      UseNTP=false
+```
+
 [systemd.network]: http://www.freedesktop.org/software/systemd/man/systemd.network.html
 [timesyncd.conf]: http://www.freedesktop.org/software/systemd/man/timesyncd.conf.html
 
-The ntpd service can be configured via the /etc/ntp.conf configuration file. It
-does not use DHCP or other configuration sources. If you would like to use a
-different set of NTP servers edit replace the `/etc/ntp.conf` symlink with
+
+## Switching between systemd-timesyncd and ntpd
+
+On CoreOS 681.0.0 or later, you can switch from *timesyncd* back
+to *ntpd* with the following commands:
+
+```
+$ sudo systemctl stop systemd-timesyncd
+$ sudo systemctl mask systemd-timesyncd
+$ sudo systemctl enable ntpd
+$ sudo systemctl start ntpd
+```
+
+or with this cloud-config snippet:
+
+```yaml
+#cloud-config
+coreos:
+  units:
+    - name: systemd-timesyncd.service
+      command: stop
+      mask: true
+    - name: ntpd.service
+      command: start
+      enable: true
+```
+
+Because timesyncd and ntpd are mutually exclusive, it's important to `mask`
+the `stop`ped service. `Systemctl disable` or `stop` alone will not prevent a
+default service from starting again.
+
+### Configuring *ntpd*
+
+The *ntpd* service reads all configuration from the file `/etc/ntp.conf`. It
+does not use DHCP or other configuration sources. To use a
+different set of NTP servers, replace the `/etc/ntp.conf` symlink with
 something like the following:
 
 ```
@@ -91,103 +201,12 @@ restrict 127.0.0.1
 restrict [::1]
 ```
 
-## Viewing the date and timezone settings with timedatectl
-
-The timedatectl command can be use to view and change timezone settings as well as report the current time.
-
-```
-timedatectl status
-      Local time: Tue 2014-08-26 19:29:12 UTC
-  Universal time: Tue 2014-08-26 19:29:12 UTC
-        RTC time: Tue 2014-08-26 19:29:12
-       Time zone: UTC (UTC, +0000)
-     NTP enabled: no
-NTP synchronized: yes
- RTC in local TZ: no
-      DST active: n/a
-```
-
-## Changing the system timezone
-
-Start by listing the available time zones:
-
-```
-timedatectl list-timezones
-Africa/Abidjan
-Africa/Accra
-Africa/Addis_Ababa
-…
-```
-
-Pick a timezone from the list and set it:
-
-```
-sudo timedatectl set-timezone America/New_York
-```
-
-Check the timezone status to view the changes:
-
-```
-timedatectl
-      Local time: Tue 2014-08-26 15:44:07 EDT
-  Universal time: Tue 2014-08-26 19:44:07 UTC
-        RTC time: Tue 2014-08-26 19:44:07
-       Time zone: America/New_York (EDT, -0400)
-     NTP enabled: no
-NTP synchronized: yes
- RTC in local TZ: no
-      DST active: yes
- Last DST change: DST began at
-                  Sun 2014-03-09 01:59:59 EST
-                  Sun 2014-03-09 03:00:00 EDT
- Next DST change: DST ends (the clock jumps one hour backwards) at
-                  Sun 2014-11-02 01:59:59 EDT
-                  Sun 2014-11-02 01:00:00 EST
-```
-
-## CoreOS Recommendations
-
-### What time should I use?
-
-To avoid time zone confusion and the complexities of adjusting clocks for
-daylight saving time it’s recommended that all machines in a CoreOS cluster use
-Coordinated Universal Time (UTC). This is the default.
-
-```
-sudo timedatectl set-timezone UTC
-```
-
-### Which NTP servers should I sync against?
-
-Unless you have a highly reliable and precise time server pool you should stick to the default NTP servers from the ntp.org server pool.
-
-```
-server 0.coreos.pool.ntp.org
-server 1.coreos.pool.ntp.org
-server 2.coreos.pool.ntp.org
-server 3.coreos.pool.ntp.org
-```
-
-## Automating with cloud-config
-
-The following cloud-config snippet can be used setup and configure NTP and timezone settings:
+Or, in cloud-config:
 
 ```yaml
 #cloud-config
-
 coreos:
-  units:
-    - name: settimezone.service
-      command: start
-      content: |
-        [Unit]
-        Description=Set the timezone
-
-        [Service]
-        ExecStart=/usr/bin/timedatectl set-timezone America/New_York
-        RemainAfterExit=yes
-        Type=oneshot
-write_files:
+  write_files:
   - path: /etc/ntp.conf
     content: |
       server 0.pool.example.com
@@ -198,8 +217,29 @@ write_files:
       restrict default nomodify nopeer noquery limited kod
       restrict 127.0.0.1
       restrict [::1]
-  - path: /etc/systemd/timesyncd.conf
-    content: |
-      [Time]
-      NTP=0.pool.example.com 1.pool.example.com
+```
+
+
+## CoreOS Recommendations
+
+### What time zone should I use?
+
+To avoid time zone confusion and the complexities of adjusting clocks for
+daylight saving time, we recommend that all machines in a CoreOS cluster use
+Coordinated Universal Time (UTC). This is the default.
+
+```
+$ sudo timedatectl set-timezone UTC
+```
+
+### Which NTP servers should I sync against?
+
+Unless you have a highly reliable and precise time server pool,
+you should stick with the default NTP servers from the ntp.org server pool.
+
+```
+server 0.coreos.pool.ntp.org
+server 1.coreos.pool.ntp.org
+server 2.coreos.pool.ntp.org
+server 3.coreos.pool.ntp.org
 ```

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -12,7 +12,7 @@ clusters.
 The [*timedatectl*(1)][timedatectl] command displays and sets the time zone
 and current time.
 
-### Show the date, time, and zone:
+### Show the date, time, and time zone:
 
 ```
 $ timedatectl status
@@ -26,9 +26,20 @@ NTP synchronized: yes
       DST active: n/a
 ```
 
+### *CoreOS Recommends: UTC time*
+To avoid time zone confusion and the complexities of adjusting clocks for
+daylight saving time (or not) in accordance with regional custom, we recommend
+that all machines in CoreOS clusters use UTC. This is the default time zone. To
+reset a machine to this default:
+
+```
+$ sudo timedatectl set-timezone UTC
+```
+
 ### Changing the time zone
 
-Start by listing the available time zones:
+If your site or application requires a different system time zone, start by
+listing the available time zones:
 
 ```
 $ timedatectl list-timezones
@@ -115,7 +126,19 @@ $ systemctl status systemd-timesyncd ntpd
 [ntp.org]: http://ntp.org/
 [systemd-timesyncd]: http://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html
 
-## Changing NTP time sources
+### CoreOS Recommends: CoreOS NTP pool
+
+Unless you have a highly reliable and precise time server pool, use the default
+CoreOS NTP servers:
+
+```
+server 0.coreos.pool.ntp.org
+server 1.coreos.pool.ntp.org
+server 2.coreos.pool.ntp.org
+server 3.coreos.pool.ntp.org
+```
+
+### Changing NTP time sources
 
 *Systemd-timesyncd* can discover NTP servers from DHCP, individual
 [network][systemd.network] configs, the file [timesyncd.conf][timesyncd.conf],
@@ -214,29 +237,4 @@ coreos:
       restrict default nomodify nopeer noquery limited kod
       restrict 127.0.0.1
       restrict [::1]
-```
-
-
-## CoreOS Recommendations
-
-### Time zone simplicity
-
-To avoid time zone confusion and the complexities of adjusting clocks for
-daylight saving time (or not) in accordance with regional custom, we recommend
-that all machines in CoreOS clusters use UTC. This is the default time zone.
-
-```
-$ sudo timedatectl set-timezone UTC
-```
-
-### Which NTP servers should I synchronize with?
-
-Unless you have a highly reliable and precise time server pool, use the default
-CoreOS NTP servers:
-
-```
-server 0.coreos.pool.ntp.org
-server 1.coreos.pool.ntp.org
-server 2.coreos.pool.ntp.org
-server 3.coreos.pool.ntp.org
 ```

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -117,11 +117,12 @@ $ sudo systemctl status systemd-timesyncd ntpd
 ## Changing NTP time sources
 
 *Systemd-timesyncd* can discover NTP servers from DHCP, individual
-[network][systemd.network] configs, [timesyncd.conf][timesyncd.conf], or use
-the built-in `*.coreos.pool.ntp.org` pool.
+[network][systemd.network] configs, the file [timesyncd.conf][timesyncd.conf],
+or the default `*.coreos.pool.ntp.org` pool.
 
-For example, to disable the default behavior of using NTP servers from DHCP,
-write the following to `/etc/systemd/network/50-dhcp-no-ntp.conf`:
+The default behavior uses NTP servers provided by DHCP. To disable this, write
+a configuration listing your preferred NTP servers into the file
+`/etc/systemd/network/50-dhcp-no-ntp.conf`:
 
 ```ini
 [Network]
@@ -134,7 +135,7 @@ UseDomains=true
 UseNTP=false
 ```
 
-The same can be accomplished with a snippet in cloud-config like:
+NTP time sources can be set with a snippet in cloud-config like:
 
 ```yaml
 #cloud-config
@@ -144,11 +145,6 @@ coreos:
     content: |
       [Time]
       NTP=0.pool.example.com 1.pool.example.com
-
-      [DHCP]
-      UseMTU=true
-      UseDomains=true
-      UseNTP=false
 ```
 
 [systemd.network]: http://www.freedesktop.org/software/systemd/man/systemd.network.html

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -91,7 +91,7 @@ CoreOS clusters use NTP to synchronize the clocks of member nodes, and all
 machines start an NTP client at boot. CoreOS versions later than
 [681.0.0][681.0.0] use [*systemd-timesyncd*(8)][systemd-timesyncd] as the
 default NTP client. Earlier versions used [*ntpd*(8)][ntp.org]. To check which
-service is active, run the follow command:
+service is active, use *systemctl* to check the status of both:
 
 ```
 $ sudo systemctl status systemd-timesyncd ntpd

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -126,7 +126,7 @@ $ systemctl status systemd-timesyncd ntpd
 [ntp.org]: http://ntp.org/
 [systemd-timesyncd]: http://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html
 
-### CoreOS Recommends: CoreOS NTP pool
+### *CoreOS Recommends: CoreOS NTP pool*
 
 Unless you have a highly reliable and precise time server pool, use the default
 CoreOS NTP servers:

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -135,7 +135,7 @@ UseDomains=true
 UseNTP=false
 ```
 
-NTP time sources can be set with a snippet in cloud-config like:
+NTP time sources can be set in `timesyncd.conf` with a cloud-config snippet like:
 
 ```yaml
 #cloud-config
@@ -230,8 +230,8 @@ $ sudo timedatectl set-timezone UTC
 
 ### Which NTP servers should I sync against?
 
-Unless you have a highly reliable and precise time server pool,
-you should stick with the default NTP servers from the ntp.org server pool.
+Unless you have a highly reliable and precise time server pool, use the default
+CoreOS NTP servers:
 
 ```
 server 0.coreos.pool.ntp.org

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -150,6 +150,12 @@ UseDomains=true
 UseNTP=false
 ```
 
+Then restart the network daemon:
+
+```
+$ sudo systemctl restart systemd-networkd
+```
+
 NTP time sources can be set in `timesyncd.conf` with a cloud-config snippet like:
 
 ```yaml

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -7,9 +7,9 @@ requirements, explains the change in NTP client daemons in recent CoreOS
 versions, and offers advice on best practices for timekeeping in CoreOS
 clusters.
 
-## Viewing and changing date and time settings with *timedatectl*
+## Viewing and changing date and time settings with `timedatectl`
 
-The [*timedatectl*(1)][timedatectl] command displays and sets the time zone
+The [`timedatectl`(1)][timedatectl] command displays and sets the time zone
 and current time.
 
 ### Show the date, time, and time zone:
@@ -101,8 +101,8 @@ coreos:
 
 CoreOS clusters use NTP to synchronize the clocks of member nodes, and all
 machines start an NTP client at boot. CoreOS versions later than
-[681.0.0][681.0.0] use [*systemd-timesyncd*(8)][systemd-timesyncd] as the
-default NTP client. Earlier versions used [*ntpd*(8)][ntp.org]. Use *systemctl*
+[681.0.0][681.0.0] use [`systemd-timesyncd`(8)][systemd-timesyncd] as the
+default NTP client. Earlier versions used [`ntpd`(8)][ntp.org]. Use `systemctl`
 to check which service is running:
 
 ```
@@ -140,8 +140,8 @@ server 3.coreos.pool.ntp.org
 
 ### Changing NTP time sources
 
-*Systemd-timesyncd* can discover NTP servers from DHCP, individual
-[network][systemd.network] configs, the file [timesyncd.conf][timesyncd.conf],
+`Systemd-timesyncd` can discover NTP servers from DHCP, individual
+[network][systemd.network] configs, the file [`timesyncd.conf`][timesyncd.conf],
 or the default `*.coreos.pool.ntp.org` pool.
 
 The default behavior uses NTP servers provided by DHCP. To disable this, write
@@ -175,10 +175,10 @@ coreos:
 [timesyncd.conf]: http://www.freedesktop.org/software/systemd/man/timesyncd.conf.html
 
 
-## Switching between systemd-timesyncd and ntpd
+## Switching between `systemd-timesyncd` and `ntpd`
 
-On CoreOS 681.0.0 or later, you can switch from *timesyncd* back
-to *ntpd* with the following commands:
+On CoreOS 681.0.0 or later, you can switch from `timesyncd` back
+to `ntpd` with the following commands:
 
 ```
 $ sudo systemctl stop systemd-timesyncd
@@ -201,13 +201,13 @@ coreos:
       enable: true
 ```
 
-Because timesyncd and ntpd are mutually exclusive, it's important to `mask`
+Because `timesyncd` and `ntpd` are mutually exclusive, it's important to `mask`
 the `stop`ped service. `Systemctl disable` or `stop` alone will not prevent a
 default service from starting again.
 
-### Configuring *ntpd*
+### Configuring `ntpd`
 
-The *ntpd* service reads all configuration from the file `/etc/ntp.conf`. It
+The `ntpd` service reads all configuration from the file `/etc/ntp.conf`. It
 does not use DHCP or other configuration sources. To use a
 different set of NTP servers, replace the `/etc/ntp.conf` symlink with
 something like the following:

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -215,7 +215,7 @@ restrict 127.0.0.1
 restrict [::1]
 ```
 
-Then reload the `ntpd` configuration:
+Then ask `ntpd` to reload its configuration:
 
 ```
 $ sudo systemctl reload ntpd

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -9,7 +9,7 @@ clusters.
 
 ## Viewing and changing date and time settings with `timedatectl`
 
-The [`timedatectl`(1)][timedatectl] command displays and sets the time zone
+The [`timedatectl(1)`][timedatectl] command displays and sets the time zone
 and current time.
 
 ### Show the date, time, and time zone:
@@ -101,8 +101,8 @@ coreos:
 
 CoreOS clusters use NTP to synchronize the clocks of member nodes, and all
 machines start an NTP client at boot. CoreOS versions later than
-[681.0.0][681.0.0] use [`systemd-timesyncd`(8)][systemd-timesyncd] as the
-default NTP client. Earlier versions used [`ntpd`(8)][ntp.org]. Use `systemctl`
+[681.0.0][681.0.0] use [`systemd-timesyncd(8)`][systemd-timesyncd] as the
+default NTP client. Earlier versions used [`ntpd(8)`][ntp.org]. Use `systemctl`
 to check which service is running:
 
 ```

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -26,7 +26,7 @@ NTP synchronized: yes
       DST active: n/a
 ```
 
-### *CoreOS Recommends: UTC time*
+### Recommended: UTC time
 To avoid time zone confusion and the complexities of adjusting clocks for
 daylight saving time (or not) in accordance with regional custom, we recommend
 that all machines in CoreOS clusters use UTC. This is the default time zone. To
@@ -126,7 +126,7 @@ $ systemctl status systemd-timesyncd ntpd
 [ntp.org]: http://ntp.org/
 [systemd-timesyncd]: http://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html
 
-### *CoreOS Recommends: NTP sources*
+### Recommended NTP sources
 
 Unless you have a highly reliable and precise time server pool, use your cloud
 provider's NTP source, or, on bare metal, the default CoreOS NTP servers:

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -90,11 +90,11 @@ coreos:
 CoreOS clusters use NTP to synchronize the clocks of member nodes, and all
 machines start an NTP client at boot. CoreOS versions later than
 [681.0.0][681.0.0] use [*systemd-timesyncd*(8)][systemd-timesyncd] as the
-default NTP client. Earlier versions used [*ntpd*(8)][ntp.org]. To check which
-service is active, use *systemctl* to check the status of both:
+default NTP client. Earlier versions used [*ntpd*(8)][ntp.org]. Use *systemctl*
+to check which service is running:
 
 ```
-$ sudo systemctl status systemd-timesyncd ntpd
+$ systemctl status systemd-timesyncd ntpd
 ● systemd-timesyncd.service - Network Time Synchronization
    Loaded: loaded (/usr/lib64/systemd/system/systemd-timesyncd.service; disabled; vendor preset: disabled)
    Active: active (running) since Thu 2015-05-14 05:43:20 UTC; 5 days ago


### PR DESCRIPTION
#### Reason
This PR aims to clarify the date/time/NTP configuration doc. #533 requests that “ntpd example should stop/mask timesyncd”. In fact the existing example did so, but was placed far away from the example describing configuration of ntpd.

#### What
* Segregated timesyncd and ntpd things in two discrete sections (533 bullet 1)
* Added restart or reload step to ntp configuration shell examples (533 bullet 2)
* Ntpd example more prominently shows/explains `mask` of stopped service. (533 bullet 3)
* Ordered topics from most to least common case.
* Moved Recommended settings close to their resp. topics so we don't say, e.g., "how to change timezone [...] oh btw don't change timezone"
* Applied basic conventions for writing `verbatim text`, `man(1)` refs. Distinguished cmd lines from stdout & file contents with `$` prompt. (Adopted simplest conventions of Go docs.)
* Prose corrected/spelled/clarified. Adopted Economist style guide
conventions for *First Use of an Acronym (FUA)* &c.
