### PR TITLE
enterprise-registry: fix script url

### DIFF
--- a/enterprise-registry/mysql-container.md
+++ b/enterprise-registry/mysql-container.md
@@ -42,7 +42,7 @@ Wait about 30 seconds for the new DB to be created before testing the connection
 Alternatively you can download a simple shell script to perform the steps above:
 
 ```sh
-curl --location https://raw.githubusercontent.com/coreos/docs/master/enterprise-registry/mysql-container/provision_mysql.sh -o /tmp/provision_mysql.sh -#
+curl --location https://raw.githubusercontent.com/coreos/docs/master/enterprise-registry/provision_mysql.sh -o /tmp/provision_mysql.sh -#
 ```
 Then run:
 


### PR DESCRIPTION
fixes https://twitter.com/emeacham/status/638791348460605440

@coreoslinux https://coreos.com/products/enterprise-registry/docs/latest/mysql-container.html … needs updated; the link to the .sh file needs "mysql-container" removed from it.

cc: @josephschorr 