### PR TITLE
A handful of corrections in the Kubernetes docs

### DIFF
--- a/kubernetes/replication-controller.md
+++ b/kubernetes/replication-controller.md
@@ -10,7 +10,7 @@ Each replication controller has a **desired state** that is managed by the appli
 
 In Kubernetes, the base unit of deployment is a **pod** ([intro to pods][pod-overview]), which is a group of containers that work together and therefore are logically grouped. The replication controller stores a **pod template** in order to create new pods if needed.
 
-Like all Kubernetes features, the replication controller makes use of label queries to inspect only the pods that it is responsible for. For example, a "frontend webapp" replication controller might be responsible for all pods matching the labels `app=myapp` and `role=frontend`. The pod template should contain these labels in order for the replication controller to manage the pods that it creates.
+Like all Kubernetes features, the replication controller makes use of label queries to inspect only the pods that it is responsible for. For example, a "frontend webapp" replication controller might be responsible for all pods matching the labels `app=webapp` and `role=frontend`. The pod template should contain these labels in order for the replication controller to manage the pods that it creates.
 
 <img src="img/controller.svg" alt="Kubernetes Replication Controller and Labels" class="img-center" />
 
@@ -49,11 +49,11 @@ Both of the examples below reference another Kubernetes feature: services. Be su
   <img src="img/rolling-deploy.svg" alt="Kubernetes Rolling Deployment" />
 </a>
 
-To execute a rolling deployment without downtime you need three Kubernetes objects: a service and two replication controllers, one for version A and one for version B.
+To execute a rolling deployment without downtime you need three Kubernetes objects: a service and two replication controllers, one for version 1 and one for version 2.
 
 The service should be configured with a fairly broad label query that will match pods created by both replication controllers, such as `app=webapp, env=prod`. Each replication controller could optionally set additional labels such as `version=X`.
 
-The rate of the deployment is controlled by the speed at which the desired count of the version A replication controller is turned down, and version B is turned up. This process could be executed manually, or more sophisticated software could be written to monitor error rates and other metrics to influence the process or halt it altogether.
+The rate of the deployment is controlled by the speed at which the desired count of the version 1 replication controller is turned down, and version 2 is turned up. This process could be executed manually, or more sophisticated software could be written to monitor error rates and other metrics to influence the process or halt it altogether.
 
 ### Traffic Shift
 
@@ -63,11 +63,11 @@ The rate of the deployment is controlled by the speed at which the desired count
 
 If your application requires all traffic to shift to the new version at the same time, a similar method can be used as above. The same three Kubernetes objects are used, but the sequence of events is different. 
 
-First, the service has a more specific label query that includes the version of the software running, such as `app=webapp, env=prod, version=A`. Instead of modifying the desired count of each replication controller, the version B controller is configured to support the same amount of load as version A.
+First, the service has a more specific label query that includes the version of the software running, such as `app=webapp, env=prod, version=1`. Instead of modifying the desired count of each replication controller, the version 2 controller is configured to support the same amount of load as version 1.
 
-After all of the pods are started (and warmed if needed), the label query of the service is modifed to include version B instead of version A. All traffic has now been shifted towards the new version.
+After all of the pods are started (and warmed if needed), the label query of the service is modifed to include version 2 instead of version 1. All traffic has now been shifted towards the new version.
 
-An advantage of this strategy is that failing back to the old version is a simple label query modification. The elegance and flexibility of Kubernetes labels shows here. Once version B is confirmed to be stable, the old replication controller and pods can be terminated.
+An advantage of this strategy is that failing back to the old version is a simple label query modification. The elegance and flexibility of Kubernetes labels shows here. Once version 2 is confirmed to be stable, the old replication controller and pods can be terminated.
 
 ## The Reconciliation Loop in Detail
 

--- a/kubernetes/services.md
+++ b/kubernetes/services.md
@@ -12,7 +12,7 @@ When creating a service, one or more **ports** can be configured. A common examp
 
 A core design feature of Kubernetes is a routable IP address for every service and pod in the cluster. Assigning IPs this way eliminates port conflicts between applications across the cluster. This allows any application team to bind to any port they require instead of reconfiguring databases or web servers to listen on non-standard ports.
 
-Google learned this lession the hard way over their decade of experience deploying this type of infrastructure and Kubernetes empowers you to avoid these mistakes before years of cruft, complexity and technical debt build up.
+Google learned this lesson the hard way over their decade of experience deploying this type of infrastructure. Kubernetes empowers you to avoid these mistakes before years of cruft, complexity and technical debt build up.
 
 While this design decision complicates the networking configuraton slightly, your operations team can set up and configure [flannel][flannel], which is an open-source project designed by CoreOS to enable this type of routing for Kubernetes.
 

--- a/kubernetes/services.md
+++ b/kubernetes/services.md
@@ -95,7 +95,7 @@ During a deployment, new pods will be launched, running the updated version of y
 
 Modifying this label query to be broad or specific is a flexible mechanism to point traffic towards a specific version of your application, either old or new, or send traffic to both at the same time.
 
-Using a label query to select the pods that receive traffic is another Google design choice that comes their container deployment experience. Maintaining a query to select pods prevents a brittle registration and removal process. Instead, pods matching the query can be constantly updated safely in an infinite loop.
+Using a label query to select the pods that receive traffic is another Google design choice that comes from their container deployment experience. Maintaining a query to select pods prevents a brittle registration and removal process. Instead, pods matching the query can be constantly updated safely in an infinite loop.
 
 Mentally compare the experience of updating a label query versus obtaining a static list of all application instances, sub-selecting the ones you care about, inspecting them to figure out if they are still valid and finally updating the load balancer with that list. 
 


### PR DESCRIPTION
services.md: fixed a misspelling, shortened a long sentence, and inserted a missing word
replication-controller.md: changed A and B to 1 and 2, since those are the versions used in the accompanying images.