### PR TITLE
*: add our golang style and development guidelines

### DIFF
--- a/golang/.godir
+++ b/golang/.godir
@@ -1,0 +1,1 @@
+github.com/coreos/docs

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,0 +1,1 @@
+FROM golang:onbuild

--- a/golang/README.md
+++ b/golang/README.md
@@ -1,0 +1,79 @@
+# Go at CoreOS
+
+We use Go (golang) a lot at CoreOS, and we’ve built up a lot of internal knowledge about how best to develop Go projects.
+
+This document serves as a best practices and style guide for how to work on new and existing CoreOS projects written in Go.
+
+## Version
+
+- Wherever possible, use the [latest official release][go-dl] of go
+- Any software shipped in the CoreOS image should be developed against the [version shipped in the CoreOS image](https://github.com/coreos/portage-stable/tree/master/dev-lang/go)
+
+[go-dl]: https://golang.org/dl/
+
+## Style
+
+Go style at CoreOS essentially just means following the upstream conventions:
+  - [Effective Go][effectivego]
+  - [CodeReviewComments][codereview]
+  - [Godoc][godoc]
+
+It's recommended to set a save hook in your editor of choice that runs `goimports` against your code.
+
+[effectivego]: https://golang.org/doc/effective_go.html
+[codereview]: https://github.com/golang/go/wiki/CodeReviewComments
+[godoc]: http://blog.golang.org/godoc-documenting-go-code
+
+## Tests
+
+- Always run [goimports][goimports] (which transitively calls `gofmt`) and `go vet`
+- Use [table-driven tests][table-driven] wherever possible ([example][table-driven-example])
+- Use [travis][travis] to run unit/integration tests against the project repository ([example][travis-example])
+- Use [SemaphoreCI][semaphore] to run functional tests where possible ([example][semaphore-example])
+- Use [GoDebug][godebug] `pretty.Compare` to compare objects (structs, maps, slices, etc.) ([example] [godebug-compare-example])
+
+[godebug]: https://github.com/kylelemons/godebug/
+[godebug-compare-example]: https://github.com/coreos-inc/auth/blob/master/functional/db_test.go#L107
+[goimports]: https://github.com/bradfitz/goimports
+[table-driven]: https://github.com/golang/go/wiki/TableDrivenTests
+[table-driven-example]: https://github.com/coreos/etcd/blob/35fddbc5d01f5e88bbc590c60f0b5e3ea8fa141b/raft/raft_paper_test.go#L186
+[travis]: https://travis-ci.org/
+[travis-example]: https://github.com/coreos/fleet/blob/master/.travis.yml
+[semaphore]: https://semaphoreci.com/
+[semaphore-example]: https://github.com/coreos/rkt/blob/master/tests/README.md
+
+## Dependencies
+
+- Carefully consider adding dependencies to your project: Do you really need it?
+- Manage third-party dependencies with [godep][godep-guide]
+
+[godep-guide]: golang/godep.md
+
+## Shared Code
+
+Idiomatic golang generally eschews creating generic utility packages in favour of implementing the necessary code as locally as possible to its use case.
+In cases where generic, utility code makes sense, though, move it to `github.com/coreos/pkg`.
+Use this repository as a first port of call when the need for generic code seems to arise.
+
+## Docker
+
+When creating Docker images from Go projects, use a combination of a `.godir` file and the `golang:onbuild` base image to produce the most simple Dockerfile for a Go project.
+The `.godir` file must contain the import path of the package being written (i.e. etcd's .godir contains "github.com/coreos/etcd").
+
+## Logging
+
+When in need of more sophisticated logging than the [stdlib log package][stdlib-log] provides, use the shared [CoreOS Log package][capnslog] (aka `capnslog`)
+
+[stdlib-log]: https://golang.org/pkg/log
+[capnslog]: https://github.com/coreos/pkg/tree/master/capnslog
+
+## CLI
+
+In anything other than the most basic CLI cases (i.e. where the [stdlib flag package][stdlib-flag] suffices), use [Cobra][cobra] to construct command-line tools.
+
+[stdlib-flag]: https://golang.org/pkg/log
+[cobra]: https://github.com/spf13/cobra
+
+## Development Tools
+
+- Use `gvm` to manage multiple versions of golang and multiple GOPATHs

--- a/golang/build
+++ b/golang/build
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+PROJ="newproj"
+ORG_PATH="github.com/coreos"
+REPO_PATH="${ORG_PATH}/${PROJ}"
+
+if [ ! -h gopath/src/${REPO_PATH} ]; then
+	mkdir -p gopath/src/${ORG_PATH}
+	ln -s ../../../.. gopath/src/${REPO_PATH} || exit 255
+fi
+
+export GOBIN=${PWD}/bin
+export GOPATH=${PWD}/gopath
+
+eval $(go env)
+
+echo "Building ${PROJ}d..."
+go build -o bin/${PROJ}d ${REPO_PATH}/${PROJ}d

--- a/golang/cover
+++ b/golang/cover
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+#
+# Generate coverage HTML for a package
+# e.g. PKG=./unit ./cover
+#
+
+if [ -z "$PKG" ]; then
+	echo "cover only works with a single package, sorry"
+	exit 255
+fi
+
+COVEROUT="coverage"
+
+if ! [ -d "$COVEROUT" ]; then
+	mkdir "$COVEROUT"
+fi
+
+# strip out slashes and dots
+COVERPKG=${PKG//\//}
+COVERPKG=${COVERPKG//./}
+
+# generate arg for "go test"
+export COVER="-coverprofile ${COVEROUT}/${COVERPKG}.out"
+
+source ./test
+
+go tool cover -html=${COVEROUT}/${COVERPKG}.out

--- a/golang/godep.md
+++ b/golang/godep.md
@@ -1,0 +1,104 @@
+## Using Godep
+
+This is a brief guide describing how we manage third-party dependencies using [`godep`](https://github.com/tools/godep). 
+We're going to use the [rkt](https://github.com/coreos/rkt) repository as an example.
+
+The [build script](https://github.com/coreos/rkt/blob/master/build) is crafted to make this transparent to most users (i.e. if you're just building rkt from source, or modifying any of the codebase without changing dependencies, you should have no need to interact with godep).
+But occasionally the need arises to either a) add a new dependency or b) update/remove an existing dependency.
+At this point, the ramblings below from an experienced Godep victim^Wenthusiast might prove of use...
+
+### Update godep
+
+Step zero is generally to ensure you have the **latest version** of `godep` available in your `PATH`.
+
+### Having the right directory layout (i.e. `GOPATH`)
+
+To work with `godep`, you'll need to have the repository (i.e. `github.com/coreos/rkt`) checked out in a valid `GOPATH`.
+If you use the [standard Go workflow](https://golang.org/doc/code.html#Organization), with every package in its proper place in a workspace, this should be no problem.
+As an example, if one was obtaining the repository for the first time, one would do the following:
+
+```
+$ export GOPATH=/tmp/foo               # or any directory you please
+$ go get -d github.com/coreos/rkt/...  # or 'git clone https://github.com/coreos/rkt $GOPATH/src/github.com/coreos/rkt'
+$ cd $GOPATH/src/github.com/coreos/rkt
+```
+
+If, however, you instead prefer to manage your source code in directories like `~/src/rkt`, there's a problem: `godep` doesn't like symbolic links (which is what the rkt `build` script [uses to create a self-contained GOPATH](https://github.com/coreos/rkt/blob/master/build#L8)).
+Hence, you'll need to work around this with bind mounts, with something like the following:
+```
+$ export GOPATH=/tmp/foo        # or any directory you please
+$ mkdir -p $GOPATH/src/github.com/coreos/rkt
+$ sudo mount --bind ~/src/rkt $GOPATH/src/github.com/coreos/rkt
+$ cd $GOPATH/src/github.com/coreos/rkt
+```
+
+One benefit of this approach over the single-workspace workflow is that checking out different versions of dependencies in the `GOPATH` (as we are about to do) is guarnteed to not affect any other packages in the `GOPATH`.
+(Using [gvm](https://github.com/moovweb/gvm) or other such tomfoolery to manage `GOPATH`s is an exercise left for the reader.)
+
+### Restoring the current state of dependencies
+
+Now that we have a functional `GOPATH`, use `godep` to restore the full set of vendored dependencies to their correct versions.
+(What this command does is essentially just loop over the set of dependencies codified in `Godeps/Godeps.json`, using `go get` to retrieve and then `git checkout` (or equivalent) to set each to their correct revision.)
+
+```
+$ godep restore # might take a while if it's the first time...
+```
+
+At this stage, your path forks, depending on what exactly you want to do: add, update or remove a dependency.
+But in _all three cases_, the procedure finishes with the [same save command](#saving-the-set-of-dependencies).
+
+#### Add a new dependency
+
+In this case you'll first need to retrieve the dependency you're working with into `GOPATH`.
+As a simple example, assuming we're adding `github.com/fizz/buzz`:
+```
+$ go get -d github.com/fizz/buzz
+```
+
+Then add your new dependency into `godep`'s purview by simply importing the standard package name in one of your sources:
+
+```
+$ vim $GOPATH/src/github.com/coreos/rkt/some/file.go
+...
+import "github.com/fizz/buzz"
+...
+```
+
+Now, GOTO [saving](#saving-the-set-of-dependencies)
+
+#### Update an existing dependency
+
+In this case, assuming we're updating `github.com/foo/bar`:
+
+```
+$ cd $GOPATH/src/github.com/foo/bar
+$ git pull   # or 'go get -d -u github.com/foo/bar/...' 
+$ git checkout $DESIRED_REVISION
+$ cd $GOPATH/src/github.com/coreos/rkt
+$ godep update github.com/foo/bar/...
+```
+
+Now, GOTO [saving](#saving-the-set-of-dependencies)
+
+#### Removing an existing dependency
+
+This is the simplest case of all: simply remove all references to a dependency from the source files.
+
+Now, GOTO [saving](#saving-the-set-of-dependencies)
+
+### Saving the set of dependencies
+
+Finally, here we are, the magic command, the holy grail, the ultimate conclusion of all `godep` operations.
+Provided you have followed the preceding instructions, regardless of whether you are adding/removing/modifying dependencies, this command will cast the necessary spells to solve all of your dependency worries:
+```
+$ godep save -r ./...
+```
+
+## Finishing up
+
+At this point, you should be good to PR.
+As well as a simple sanity check that the code actually builds and tests pass, here are some things to look out for:
+- `git status Godeps/` should show only a minimal and relevant change (i.e. only the dependencies you actually intended to touch).
+- `git diff Godeps/` should be free of any changes to import paths within the vendored dependencies
+- `git diff` should show _all_ third-party import paths prefixed with `Godeps/_workspace`
+- If something looks awry, restart, pray to your preferred deity, and try again.

--- a/golang/test
+++ b/golang/test
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+#
+# Run all tests (not including functional)
+#   ./test
+#   ./test -v
+#
+# Run tests for one package
+#   PKG=./foo ./test
+#   PKG=bar ./test
+#
+
+# Invoke ./cover for HTML output
+COVER=${COVER:-"-cover"}
+
+source ./build
+
+TESTABLE="foo bar"
+FORMATTABLE="$TESTABLE baz"
+
+# user has not provided PKG override
+if [ -z "$PKG" ]; then
+	TEST=$TESTABLE
+	FMT=$FORMATTABLE
+
+# user has provided PKG override
+else
+	# strip out slashes and dots from PKG=./foo/
+	TEST=${PKG//\//}
+	TEST=${TEST//./}
+
+	# only run gofmt on packages provided by user
+	FMT="$TEST"
+fi
+
+# split TEST into an array and prepend REPO_PATH to each local package
+split=(${TEST// / })
+TEST=${split[@]/#/${REPO_PATH}/}
+
+echo "Running tests..."
+go test ${COVER} $@ ${TEST}
+
+echo "Checking gofmt..."
+fmtRes=$(gofmt -l $FMT)
+if [ -n "${fmtRes}" ]; then
+	echo -e "gofmt checking failed:\n${fmtRes}"
+	exit 255
+fi
+
+echo "Checking govet..."
+vetRes=$(go vet $TEST)
+if [ -n "${vetRes}" ]; then
+	echo -e "govet checking failed:\n${vetRes}"
+	exit 255
+fi
+
+echo "Success"


### PR DESCRIPTION
We were previously hosting those internally, but as the vast majority of
CoreOS projects are developed in the open, we should share them and have
them publicly referenceable for anyone working on CoreOS projects.