### PR TITLE
Change file permission to '0644'

### DIFF
--- a/os/registry-authentication.md
+++ b/os/registry-authentication.md
@@ -47,7 +47,7 @@ Since each machine in your cluster is going to have to pull images, cloud-config
 write_files:
     - path: /home/core/.dockercfg
       owner: core:core
-      permissions: 0644
+      permissions: '0644'
       content: |
         {
           "https://index.docker.io/v1/": {


### PR DESCRIPTION
Projects like https://github.com/coreos/coreos-vagrant YAML.load and YAML.dump the cloud-config which changes octal 0644 to decimal 420, which is inconvenient if you prefer configs consistently use the same radix.