### PR TITLE
Correcting the ECS Agent systemd unit file.

### DIFF
--- a/os/booting-on-ecs.md
+++ b/os/booting-on-ecs.md
@@ -21,21 +21,37 @@ coreos:
      runtime: true
      content: |
        [Unit]
-       Description=Amazon ECS Agent
-       After=docker.service
-       Requires=docker.service
-       Requires=network-online.target
-       After=network-online.target
-       
+       Description=AWS ECS Agent (https://github.com/aws/amazon-ecs-agent)
+       Documentation=https://docs.aws.amazon.com/AmazonECS/latest/developerguide/
+       Requires=network-online.target docker.socket
+       After=network.target docker.socket
+
        [Service]
        Environment=ECS_CLUSTER=your_cluster_name
-       Environment=ECS_LOGLEVEL=warn
-       Environment=ECS_CHECKPOINT=true
+       Environment=ECS_LOGLEVEL=info
+       Environment=ECS_VERSION=latest
+       Restart=on-failure
+       RestartSec=30
+       RestartPreventExitStatus=5
+       SyslogIdentifier=ecs-agent
+       ExecStartPre=-/bin/mkdir -p /var/log/ecs /var/ecs-data /etc/ecs
+       ExecStartPre=-/usr/bin/touch /etc/ecs/ecs.config
        ExecStartPre=-/usr/bin/docker kill ecs-agent
        ExecStartPre=-/usr/bin/docker rm ecs-agent
-       ExecStartPre=/usr/bin/docker pull amazon/amazon-ecs-agent
-       ExecStart=/usr/bin/docker run --name ecs-agent --env=ECS_CLUSTER=${ECS_CLUSTER} --env=ECS_LOGLEVEL=${ECS_LOGLEVEL} --env=ECS_CHECKPOINT=${ECS_CHECKPOINT} --publish=127.0.0.1:51678:51678 --volume=/var/run/docker.sock:/var/run/docker.sock --volume=/var/lib/aws/ecs:/data amazon/amazon-ecs-agent
-       ExecStop=/usr/bin/docker stop ecs-agent
+       ExecStartPre=/usr/bin/docker pull amazon/amazon-ecs-agent:${ECS_VERSION}
+       ExecStart=/usr/bin/docker run --name ecs-agent \
+                                     --env-file=/etc/ecs/ecs.config \
+                                     --volume=/var/run/docker.sock:/var/run/docker.sock \
+                                     --volume=/var/log/ecs:/log \
+                                     --volume=/var/ecs-data:/data \
+                                     --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro \
+                                     --volume=/run/docker/execdriver/native:/var/lib/docker/execdriver/native:ro \
+                                     --publish=127.0.0.1:51678:51678 \
+                                     --env=ECS_LOGFILE=/log/ecs-agent.log \
+                                     --env=ECS_LOGLEVEL=${ECS_LOGLEVEL} \
+                                     --env=ECS_DATADIR=/data \
+                                     --env=ECS_CLUSTER=${ECS_CLUSTER} \
+                                     amazon/amazon-ecs-agent:${ECS_VERSION}
 ```
 
 The example above pulls the latest official Amazon ECS agent container from the Docker Hub when the machine starts. If you ever need to update the agent, it’s as simple as restarting the amazon-ecs-agent service or the CoreOS machine.

--- a/os/booting-on-ecs.md
+++ b/os/booting-on-ecs.md
@@ -21,10 +21,10 @@ coreos:
      runtime: true
      content: |
        [Unit]
-       Description=AWS ECS Agent (https://github.com/aws/amazon-ecs-agent)
+       Description=AWS ECS Agent
        Documentation=https://docs.aws.amazon.com/AmazonECS/latest/developerguide/
        Requires=network-online.target docker.socket
-       After=network.target docker.socket
+       After=docker.socket
 
        [Service]
        Environment=ECS_CLUSTER=your_cluster_name

--- a/os/booting-on-ecs.md
+++ b/os/booting-on-ecs.md
@@ -23,7 +23,7 @@ coreos:
        [Unit]
        Description=AWS ECS Agent
        Documentation=https://docs.aws.amazon.com/AmazonECS/latest/developerguide/
-       Requires=network-online.target docker.socket
+       Requires=docker.socket
        After=docker.socket
 
        [Service]


### PR DESCRIPTION
This change makes sure that the new CloudWatch Metrics[1] get reported correctly. Also, the old version of the unit file was missing some flag / switches the ec-agent docs have.[2] This will bring the ECS docs and the CoreOS example inline.

[1] http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-metrics.html
[2] http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-install.html