### PR TITLE
os/selinux: Make more consistent with other docs; explain cmds.

### DIFF
--- a/os/selinux.md
+++ b/os/selinux.md
@@ -1,4 +1,4 @@
-# Using SELinux on CoreOS
+# SELinux on CoreOS
 
 SELinux is a fine-grained access control mechanism integrated into
 CoreOS and rkt. Each container runs in its own independent SELinux context,
@@ -10,40 +10,50 @@ by default. This allows deployers to verify container operation before enabling
 SELinux enforcement. This document covers the process of checking containers
 for SELinux policy compatibility, and switching SELinux into `enforcing` mode.
 
-## Checking a Container's Compatibility with SELinux Policy
+## Check a Container's Compatibility with SELinux Policy
 
 To verify whether the current SELinux policy would inhibit your containers,
-enable SELinux logging by running the following commands as root:
+enable SELinux logging. In the following set of commands, we delete the rules that suppress this logging by default, and copy the policy store from CoreOS's read-only `/usr` to a writable file system location.
 
-* `rm /etc/audit/rules.d/80-selinux.rules`
-* `rm /etc/audit/rules.d/99-default.rules`
-* `rm /etc/selinux/mcs`
-* `cp -a /usr/lib/selinux/mcs /etc/selinux`
-* `rm /var/lib/selinux`
-* `cp -a /usr/lib/selinux/policy /var/lib/selinux`
-* `semodule -DB`
-* `systemctl restart audit-rules`
+```sh
+$ rm /etc/audit/rules.d/80-selinux.rules
+$ rm /etc/audit/rules.d/99-default.rules
+$ rm /etc/audit/rules.d/99-default.rules
+$ rm /etc/selinux/mcs
+$ cp -a /usr/lib/selinux/mcs /etc/selinux
+$ rm /var/lib/selinux
+$ cp -a /usr/lib/selinux/policy /var/lib/selinux
+$ semodule -DB
+$ systemctl restart audit-rules
+```
 
 Now run your container. Check the system logs for any messages containing
 `avc: denied`. Such messages indicate that an `enforcing` SELinux would prevent
 the container from performing the logged operation. Please open an issue at
-[coreos/bugs](https://github.com/coreos/bugs/issues), including the full avc log
-message.
+[coreos/bugs](https://github.com/coreos/bugs/issues), including the full avc
+log message.
 
-## Enabling SELinux Enforcement
+## Enable SELinux Enforcement
 
 Once satisfied that your container workload is compatible with the SELinux
 policy, you can temporarily enable enforcement by running the following command
 as root:
 
-* `$ setenforce 1`
+`$ setenforce 1`
 
 A reboot will reset SELinux to `permissive` mode.
 
-To enable SELinux enforcement across reboots, do the following:
+### Make SELinux Enforcement Permanent
 
-* `$ cp --remove-destination $(readlink -f /etc/selinux/config) /etc/selinux/config`
-* Edit `/etc/selinux/config` and replace "SELINUX=permissive" with "SELINUX=enforcing"
+To enable SELinux enforcement across reboots, replace the symbolic link
+`/etc/selinux/config` with the file it targets, so that the file can be written.
+You can use the `readlink` command to dereference the link, as shown in the
+following one-liner:
+
+`$ cp --remove-destination $(readlink -f /etc/selinux/config) /etc/selinux/config`
+
+Now, edit `/etc/selinux/config` to replace `SELINUX=permissive` with
+`SELINUX=enforcing`.
 
 ## Limitations
 


### PR DESCRIPTION
Eliminate the bullet points per step that were unlike other docs.
Minimally explicate the commands we're running.
Prefix all cmd lines with the prompt `$` to distinguish I from O.

(Finishes up what started in #661, #665, and #666.)