### PR TITLE
Disable locksmithd when you disable update-engine to avoid errors in journal

### DIFF
--- a/os/update-strategies.md
+++ b/os/update-strategies.md
@@ -77,7 +77,7 @@ An easy solution to this problem is to use iPXE and reference images [directly f
 
 ## Disable Automatic Updates Daemon
 
-In case when you don't want to install updates onto the passive partition and avoid update process on failure reboot, you can disable `update-engine` service manually with `sudo systemctl stop update-engine` command (it will be enabled automatically next reboot). Or if you wish to disable automatic updates permanently, use Cloud-Config (you should also stop `locksmithd` since it will report a lot of errors when `update-engine` is not running):
+In case when you don't want to install updates onto the passive partition and avoid update process on failure reboot, you can disable `update-engine` service manually with `sudo systemctl stop update-engine` command (it will be enabled automatically next reboot). Or if you wish to disable automatic updates permanently, use Cloud-Config (you should also stop `locksmithd` in this case since it will constantly report errors when `update-engine` is not running):
 
 ```yaml
 #cloud-config

--- a/os/update-strategies.md
+++ b/os/update-strategies.md
@@ -77,7 +77,9 @@ An easy solution to this problem is to use iPXE and reference images [directly f
 
 ## Disable Automatic Updates Daemon
 
-In case when you don't want to install updates onto the passive partition and avoid update process on failure reboot, you can disable `update-engine` service manually with `sudo systemctl stop update-engine` command (it will be enabled automatically next reboot). Or if you wish to disable automatic updates permanently, use Cloud-Config (you should also stop `locksmithd` in this case since it will constantly report errors when `update-engine` is not running):
+In case when you don't want to install updates onto the passive partition and avoid update process on failure reboot, you can disable `update-engine` service manually with `sudo systemctl stop update-engine` command (it will be enabled automatically next reboot).
+
+If you wish to disable automatic updates permanently, use can configure this with Cloud-Config. This example will stop `update-engine`, which executes the updates, and `locksmithd`, which coordinates reboots across the cluster:
 
 ```yaml
 #cloud-config

--- a/os/update-strategies.md
+++ b/os/update-strategies.md
@@ -77,13 +77,15 @@ An easy solution to this problem is to use iPXE and reference images [directly f
 
 ## Disable Automatic Updates Daemon
 
-In case when you don't want to install updates onto the passive partition and avoid update process on failure reboot, you can disable `update-engine` service manually with `sudo systemctl stop update-engine` command (it will be enabled automatically next reboot). Or if you wish to disable automatic updates permanently, use Cloud-Config:
+In case when you don't want to install updates onto the passive partition and avoid update process on failure reboot, you can disable `update-engine` service manually with `sudo systemctl stop update-engine` command (it will be enabled automatically next reboot). Or if you wish to disable automatic updates permanently, use Cloud-Config (you should also stop `locksmithd` since it will report a lot of errors when `update-engine` is not running):
 
 ```yaml
 #cloud-config
 coreos:
   units:
     - name: update-engine.service
+      command: stop
+    - name: locksmithd.service
       command: stop
 ```
 


### PR DESCRIPTION
If `locksmithd` is running it complains constantly:

```
Jan 04 12:34:09 dev112-43 systemd[1]: Started Cluster reboot manager.
Jan 04 12:34:09 dev112-43 locksmithd[26936]: Cannot get update engine status: The name com.coreos.update1 was not provided by any .service files
Jan 04 12:34:09 dev112-43 systemd[1]: locksmithd.service: Main process exited, code=exited, status=1/FAILURE
Jan 04 12:34:09 dev112-43 systemd[1]: locksmithd.service: Unit entered failed state.
Jan 04 12:34:09 dev112-43 systemd[1]: locksmithd.service: Failed with result 'exit-code'.
Jan 04 12:34:19 dev112-43 systemd[1]: locksmithd.service: Service hold-off time over, scheduling restart.
Jan 04 12:34:19 dev112-43 systemd[1]: Stopped Cluster reboot manager.
```