### PR TITLE
Added "trap" into docker "while" loop examples

### DIFF
--- a/fleet/launching-containers-fleet.md
+++ b/fleet/launching-containers-fleet.md
@@ -55,7 +55,7 @@ TimeoutStartSec=0
 ExecStartPre=-/usr/bin/docker kill busybox1
 ExecStartPre=-/usr/bin/docker rm busybox1
 ExecStartPre=/usr/bin/docker pull busybox
-ExecStart=/usr/bin/docker run --name busybox1 busybox /bin/sh -c "while true; do echo Hello World; sleep 1; done"
+ExecStart=/usr/bin/docker run --name busybox1 busybox /bin/sh -c "trap 'exit 0' INT TERM; while true; do echo Hello World; sleep 1; done"
 ExecStop=/usr/bin/docker stop busybox1
 ```
 

--- a/os/getting-started-with-systemd.md
+++ b/os/getting-started-with-systemd.md
@@ -25,7 +25,7 @@ TimeoutStartSec=0
 ExecStartPre=-/usr/bin/docker kill busybox1
 ExecStartPre=-/usr/bin/docker rm busybox1
 ExecStartPre=/usr/bin/docker pull busybox
-ExecStart=/usr/bin/docker run --name busybox1 busybox /bin/sh -c "while true; do echo Hello World; sleep 1; done"
+ExecStart=/usr/bin/docker run --name busybox1 busybox /bin/sh -c "trap 'exit 0' INT TERM; while true; do echo Hello World; sleep 1; done"
 
 [Install]
 WantedBy=multi-user.target

--- a/os/quickstart.md
+++ b/os/quickstart.md
@@ -136,7 +136,7 @@ TimeoutStartSec=0
 ExecStartPre=-/usr/bin/docker kill hello
 ExecStartPre=-/usr/bin/docker rm hello
 ExecStartPre=/usr/bin/docker pull busybox
-ExecStart=/usr/bin/docker run --name hello busybox /bin/sh -c "while true; do echo Hello World; sleep 1; done"
+ExecStart=/usr/bin/docker run --name hello busybox /bin/sh -c "trap 'exit 0' INT TERM; while true; do echo Hello World; sleep 1; done"
 ExecStop=/usr/bin/docker stop hello
 ```
 
@@ -160,8 +160,7 @@ $ fleetctl status hello.service
    Active: active (running) since Wed 2014-06-04 19:04:13 UTC; 44s ago
  Main PID: 27503 (bash)
    CGroup: /system.slice/hello.service
-           ├─27503 /bin/bash -c /usr/bin/docker start -a hello || /usr/bin/docker run --name hello busybox /bin/sh -c "while true; do echo Hello World; sleep 1; done"
-           └─27509 /usr/bin/docker run --name hello busybox /bin/sh -c while true; do echo Hello World; sleep 1; done
+           └─27503 /usr/bin/docker run --name hello busybox /bin/sh -c trap 'exit 0' INT TERM; while true; do echo Hello World; sleep 1; done
 
 Jun 04 19:04:57 core-01 bash[27503]: Hello World
 ..snip...

--- a/os/registry-authentication.md
+++ b/os/registry-authentication.md
@@ -36,7 +36,7 @@ After=docker.service
 
 [Service]
 User=core
-ExecStart=/usr/bin/docker run busybox /bin/sh -c "while true; do echo Hello World; sleep 1; done"
+ExecStart=/usr/bin/docker run busybox /bin/sh -c "trap 'exit 0' INT TERM; while true; do echo Hello World; sleep 1; done"
 
 [Install]
 WantedBy=multi-user.target

--- a/os/using-environment-variables-in-systemd-units.md
+++ b/os/using-environment-variables-in-systemd-units.md
@@ -57,7 +57,7 @@ EnvironmentFile=/etc/fleet_machines.env
 ExecStartPre=-/usr/bin/docker kill %p
 ExecStartPre=-/usr/bin/docker rm %p
 ExecStartPre=/usr/bin/docker pull ubuntu:latest
-ExecStart=/usr/bin/docker run --rm --name %p -e FLEET_MACHINES ubuntu:latest bash -c 'while true; do echo "$FLEET_MACHINES"; sleep 1; done'
+ExecStart=/usr/bin/docker run --rm --name %p -e FLEET_MACHINES ubuntu:latest /bin/bash -c "trap 'exit 0' INT TERM; while true; do echo "$FLEET_MACHINES"; sleep 1; done"
 ```
 
 ## Another Examples


### PR DESCRIPTION
When you don't use `trap`, `bash`/`sh` doesn't catch TERM signal which `docker stop` sends.
This causes `docker stop` timeout and then `docker kill`.

/cc @robszumski @joshix 

steps to reproduce with the Ubuntu container + bash (this example doesn't handle INT):

* `docker run -ti --rm ubuntu /bin/bash -c "while true; do echo hello world; sleep 1; done"`
* try to type `Ctrl+C`

or this busybox example doesn't handle TERM:

* `docker run -ti --name busybox --rm busybox /bin/sh -c "while true; do echo hello world; sleep 1; done"`
* Then in another window to run `docker stop busybox` it will timeout, then docker will kill it.

Both examples with the `trap 'exit 0' INT TERM;` work fine.