### PR TITLE
STYLE: Fix model heading to sentence case

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -76,7 +76,7 @@ The abridged skeletal markdown source for this document's headings:
 
 [...]
 
-## Hyperlink Considerations
+## Hyperlink considerations
 
 ### Naming
 


### PR DESCRIPTION
Tiny nit has been bugging me for a while. This model
headings structure is probably going the way of the
dodo soon.