### PR TITLE
os/: Fix links that were externally declared

### DIFF
--- a/os/booting-on-ec2.md
+++ b/os/booting-on-ec2.md
@@ -224,12 +224,12 @@ You need open port 2379, 2380, 7001 and 4001 between servers in the `etcd` clust
 
 _This step is only needed once_
 
-First we need to create a security group to allow CoreOS instances to communicate with one another. 
+First we need to create a security group to allow CoreOS instances to communicate with one another.
 
 1. Go to the [security group][sg] page in the EC2 console.
 2. Click "Create Security Group"
     * Name: coreos-testing
-    * Description: CoreOS instances 
+    * Description: CoreOS instances
     * VPC: No VPC
     * Click: "Yes, Create"
 3. In the details of the security group, click the `Inbound` tab
@@ -298,7 +298,7 @@ coreos:
       command: start
 </pre>
         <li>
-          Back in the EC2 dashboard, paste this information verbatim into the "User Data" field. 
+          Back in the EC2 dashboard, paste this information verbatim into the "User Data" field.
           <ul>
             <li>Paste link into "User Data"</li>
             <li>"Continue"</li>
@@ -377,7 +377,7 @@ coreos:
       command: start
 </pre>
         <li>
-          Back in the EC2 dashboard, paste this information verbatim into the "User Data" field. 
+          Back in the EC2 dashboard, paste this information verbatim into the "User Data" field.
           <ul>
             <li>Paste link into "User Data"</li>
             <li>"Continue"</li>
@@ -456,7 +456,7 @@ coreos:
       command: start
 </pre>
         <li>
-          Back in the EC2 dashboard, paste this information verbatim into the "User Data" field. 
+          Back in the EC2 dashboard, paste this information verbatim into the "User Data" field.
           <ul>
             <li>Paste link into "User Data"</li>
             <li>"Continue"</li>
@@ -507,3 +507,9 @@ rollbacks to work properly on Amazon EC2.
 
 Now that you have a machine booted it is time to play around.
 Check out the [CoreOS Quickstart]({{site.baseurl}}/docs/quickstart) guide or dig into [more specific topics]({{site.baseurl}}/docs).
+
+
+[coreos-dev]: https://groups.google.com/forum/#!forum/coreos-dev
+[docker-docs]: https://docs.docker.io
+[etcd-docs]: {{site.baseurl}}/etcd/docs/latest/
+[irc]: irc://irc.freenode.org:6667/#coreos

--- a/os/booting-on-vagrant.md
+++ b/os/booting-on-vagrant.md
@@ -281,3 +281,7 @@ vagrant box add coreos-alpha <path-to-box-file>
 
 Now that you have a machine booted it is time to play around.
 Check out the [CoreOS Quickstart]({{site.baseurl}}/docs/quickstart) guide, learn about [CoreOS clustering with Vagrant]({{site.baseurl}}/blog/coreos-clustering-with-vagrant/), or dig into [more specific topics]({{site.baseurl}}/docs).
+
+
+[coreos-dev]: https://groups.google.com/forum/#!forum/coreos-dev
+[irc]: irc://irc.freenode.org:6667/#coreos

--- a/os/booting-with-libvirt.md
+++ b/os/booting-with-libvirt.md
@@ -225,3 +225,7 @@ network):
 ```sh
 cat /var/lib/libvirt/dnsmasq/default.leases
 ```
+
+
+[coreos-dev]: https://groups.google.com/forum/#!forum/coreos-dev
+[irc]: irc://irc.freenode.org:6667/#coreos

--- a/os/booting-with-pxe.md
+++ b/os/booting-with-pxe.md
@@ -195,3 +195,7 @@ usr/share/oem/cloud-config.yml
 
 Now that you have a machine booted it is time to play around.
 Check out the [CoreOS Quickstart]({{site.baseurl}}/docs/quickstart) guide or dig into [more specific topics]({{site.baseurl}}/docs).
+
+
+[coreos-dev]: https://groups.google.com/forum/#!forum/coreos-dev
+[irc]: irc://irc.freenode.org:6667/#coreos

--- a/os/booting-with-qemu.md
+++ b/os/booting-with-qemu.md
@@ -186,3 +186,7 @@ ssh coreos
 
 Now that you have a machine booted it is time to play around.
 Check out the [CoreOS Quickstart]({{site.baseurl}}/docs/quickstart) guide or dig into [more specific topics]({{site.baseurl}}/docs).
+
+
+[coreos-dev]: https://groups.google.com/forum/#!forum/coreos-dev
+[irc]: irc://irc.freenode.org:6667/#coreos

--- a/os/quickstart.md
+++ b/os/quickstart.md
@@ -100,7 +100,7 @@ If you followed a guide to set up more than one CoreOS machine, you can SSH into
 
 The second building block, **Docker** ([docs][docker-docs]), is where your applications and code run. It is installed on each CoreOS machine. You should make each of your services (web server, caching, database) into a container and connect them together by reading and writing to etcd. You can quickly try out a minimal busybox container in two different ways:
 
-Run a command in the container and then stop it: 
+Run a command in the container and then stop it:
 
 ```sh
 docker run busybox /bin/echo hello world
@@ -178,3 +178,8 @@ Fleet has many more features that you can explore in the guides below.
 #### More Detailed Information
 <a class="btn btn-primary" href="{{ site.baseurl }}/docs/launching-containers/launching/launching-containers-fleet/" data-category="More Information" data-event="Docs: Launching Containers Fleet">View Complete Guide</a>
 <a class="btn btn-default" href="{{ site.baseurl }}/docs/launching-containers/launching/getting-started-with-systemd/" data-category="More Information" data-event="Docs: Getting Started with systemd">View Getting Started with systemd Guide</a>
+
+
+[docker-docs]: https://docs.docker.io
+[etcd-docs]: {{site.baseurl}}/etcd/docs/latest/
+[vagrant-guide]: booting-on-vagrant.md


### PR DESCRIPTION
Repair markdown links that were using the removed external
reference links jekyll plugin.

Related to ~~and should merge along with~~ coreos-inc/coreos-pages#440.

(not necessary to merge simultaneously with the related, larger changes in the existing site (440), but the two should go fairly close together, logically)