### PR TITLE
os/gce: Update quickstart link

### DIFF
--- a/os/booting-on-google-compute-engine.md
+++ b/os/booting-on-google-compute-engine.md
@@ -3,7 +3,7 @@
 Before proceeding, you will need a GCE account ([get $300 of credit here][free-trial]) and [install gcloud][gcloud-documentation] on your machine. In each command below, be sure to insert your project name in place of `<project-id>`.
 
 [gce-advanced-os]: http://developers.google.com/compute/docs/transition-v1#customkernelbinaries
-[gcloud-documentation]: https://developers.google.com/cloud/sdk/
+[gcloud-documentation]: https://cloud.google.com/sdk/
 [free-trial]: https://cloud.google.com/free-trial/?utm_source=coreos&utm_medium=partners&utm_campaign=partner-free-trial
 
 After installation, log into your account with `gcloud auth login` and enter your project ID when prompted.


### PR DESCRIPTION
developers. redirects to cloud.google.com. Use the newer link.