### PR TITLE
etcd/live-reconfiguration: Clean up style, language atop #749

### DIFF
--- a/etcd/etcd-live-cluster-reconfiguration.md
+++ b/etcd/etcd-live-cluster-reconfiguration.md
@@ -1,10 +1,10 @@
 # etcd Cluster Runtime Reconfiguration on CoreOS
 
-Use this document to reconfigure or recover an etcd cluster running on CoreOS, using a combination of systemd features and etcdctl commands.
+This document describes the reconfiguration or recovery of an etcd cluster running on CoreOS, using a combination of `systemd` features and `etcdctl` commands.
 
-## Change the etcd Cluster Size
+## Change etcd cluster size
 
-When you use [Cloud-Config][cloud-config] to configure etcd member on your CoreOS node it compiles special `/run/systemd/system/etcd2.service.d/20-cloudinit.conf` [drop-in] unit file. I.e. Cloud-Config below: 
+When [cloud-config][cloud-config] is used to configure an etcd member on a CoreOS node, it compiles a special `/run/systemd/system/etcd2.service.d/20-cloudinit.conf` [drop-in unit file][drop-in]. That is, the cloud-config below:
 
 ```yaml
 #cloud-config
@@ -18,7 +18,7 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
 ```
 
-will generate following [drop-in]:
+will generate the following [drop-in][drop-in]:
 
 ```ini
 [Service]
@@ -29,11 +29,11 @@ Environment="ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379,http://0.0.0.0:4001"
 Environment="ETCD_LISTEN_PEER_URLS=http://0.0.0.0:2380"
 ```
 
-If you have etcd cluster with TLS, just use `https://` instead of `http://` in commands' examples below.
+If the etcd cluster is secured with TLS, use `https://` instead of `http://` in the command examples below.
 
-Let's assume that you have created five-nodes CoreOS cluster but have forgot to set cluster size in [discovery][etcd-discovery] URL and its cluster size is three by default. Your rest two nodes became proxy and you would like to convert them to etcd2 member.
+Assume that you have created a five-node CoreOS cluster, but did not specify cluster size in the [discovery][etcd-discovery] URL. Since the default discovery cluster size is 3, the remaining two nodes were configured as proxies. You would like to promote these proxies to full etcd cluster members, without bootstrapping a new etcd cluster.
 
-You can solve this problem without new cluster bootstrapping. Just run `etcdctl member add node4 http://10.0.1.4:2380` and remember its output (we will use it later):
+The existing cluster can be reconfigured. Run `etcdctl member add node4 http://10.0.1.4:2380`. Later steps will use information from the output of this command, so it's a good idea to copy and paste it somewhere convenient. The output of a successful member addition will look like this:
 
 ```
 added member 9bf1b35fc7761a23 to cluster
@@ -43,9 +43,9 @@ ETCD_INITIAL_CLUSTER="1dc800dbf6a732d8839bc71d0538bb99=http://10.0.1.1:2380,f961
 ETCD_INITIAL_CLUSTER_STATE=existing
 ```
 
-Already defined in `20-cloudinit.conf` `ETCD_DISCOVERY` conflicts with `ETCD_INITIAL_CLUSTER` environment variable, so we have to clean it. We can do that overriding `20-cloudinit.conf` by `99-restore.conf` drop-in with the `Environment="ETCD_DISCOVERY="` string.
+The `ETCD_DISCOVERY` environment variable defined in `20-cloudinit.conf` conflicts with the `ETCD_INITIAL_CLUSTER` setting needed for these steps, so the first step is clearing it by overriding `20-cloudinit.conf` with a new drop-in, `99-restore.conf`. `99-restore.conf` contains an empty `Environment="ETCD_DISCOVERY="` string.
 
-The complete example will look this way. On `node4` CoreOS host create temporarily systemd drop-in unit `/run/systemd/system/etcd2.service.d/99-restore.conf` with the content below (we use variables from `etcdctl member add` output):
+The complete example looks like this. On the `node4` CoreOS host, create a  temporary systemd drop-in, `/run/systemd/system/etcd2.service.d/99-restore.conf` with the contents below, filling in the information from the output of the `etcd member add` command we ran previously:
 
 ```ini
 [Service]
@@ -62,21 +62,19 @@ Environment="ETCD_INITIAL_CLUSTER=node1=http://10.0.1.1:2380,node2=http://10.0.1
 Environment="ETCD_INITIAL_CLUSTER_STATE=existing"
 ```
 
-**NOTE:** make sure you've removed double quotes just after `ETCD_INITIAL_CLUSTER=` entry.
-
-Run `sudo systemctl daemon-reload`, check whether new [drop-in] is valid: `sudo journalctl _PID=1 -e -u etcd2` and if everything is ok run `sudo systemctl restart etcd2` to apply your changes. You will see that your proxy node became cluster member:
+Run `sudo systemctl daemon-reload` to parse the new and edited units. Check whether the new [drop-in][drop-in] is valid by checking the service's journal: `sudo journalctl _PID=1 -e -u etcd2`. If everything is ok, run `sudo systemctl restart etcd2` to activate your changes. You will see that the former proxy node has become a cluster member:
 
 ```
 etcdserver: start member 9bf1b35fc7761a23 in cluster 36cce781cb4f1292
 ```
 
-Once your new member node is up and running and `etcdctl cluster-health` shows healthy cluster, you have to remove your temporarily drop-in `sudo rm /run/systemd/system/etcd2.service.d/99-restore.conf && sudo systemctl daemon-reload`.
+Once your new member node is up and running, and `etcdctl cluster-health` shows a healthy cluster, remove the temporary drop-in file and reparse the services: `sudo rm /run/systemd/system/etcd2.service.d/99-restore.conf && sudo systemctl daemon-reload`.
 
-## Replace A Failed etcd Member on CoreOS
+## Replace a failed etcd member on CoreOS
 
-Here you will find step-by-step instructions on how to recover your failed etcd member. It is important to know that you can not restore your etcd cluster using only discovery URL. Discovery URL is used only once at bootstrap.
+This section provides instructions on how to recover a failed etcd member. It is important to know that an etcd cluster cannot be restored using only a discovery URL; the discovery URL is used only once during cluster bootstrap.
 
-In this example we will review 3-members etcd cluster with one failed node (and your cluster didn't lose [quorum][majority] and is alive). etcd member node could be failed by several reasons: out of disk space, incorrect reboot, and other reasons. It is important to take into consideration that this example assumes you used [Cloud-Config][cloud-config] with [discovery URL][etcd-discovery] to bootstrap your cluster with the following default options:
+In this example, we use a 3-member etcd cluster with one failed node, that is still running and has maintained [quorum][majority]. An etcd member node might fail for several reasons: out of disk space, an incorrect reboot, or issues on the underlying system. Note that this example assumes you used [cloud-config][cloud-config] with an etcd [discovery URL][etcd-discovery] to bootstrap your cluster, with the following default options:
 
 ```yaml
 #cloud-config
@@ -90,7 +88,9 @@ coreos:
     discovery: https://discovery.etcd.io/<token>
 ```
 
-If you have etcd cluster with TLS, just use `https://` instead of `http://` in commands' examples below. Let's assume that your etcd cluster has faulty `10.0.1.2` member:
+If the etcd cluster is protected with TLS, use `https://` instead of `http://` in the examples below.
+
+Let's assume that your etcd cluster has a faulty member `10.0.1.2`:
 
 ```sh
 $ etcdctl cluster-health
@@ -101,40 +101,34 @@ member 60e8a32b09dc91f1 is healthy: got healthy result from http://10.0.1.3:2379
 cluster is healthy
 ```
 
-We have to run `etcdctl` from a working node, or just use [`ETCDCTL_ENDPOINT`][etcdctl-endpoint] environment variable or parameter to specify `etcdctl` to use healthy member node.
+Run `etcdctl` from a working node, or use the [`ETCDCTL_ENDPOINT`][etcdctl-endpoint] environment variable or command line option to point `etcdctl` at any healthy member node.
 
-Then we have to [remove failed][etcdctl-member-remove] 10.0.1.2 member from your etcd cluster. This will tell all the other nodes in the cluster that a human has determined this node is dead and not to connect to it ever again:
+[Remove the failed member][etcdctl-member-remove] `10.0.1.2` from the etcd cluster. The remove subcommand informs all other cluster nodes that a human has determined this node is dead and not available for connections:
 
 ```sh
 $ etcdctl member remove 1609b5a3a078c227
 Removed member 1609b5a3a078c227 from cluster
 ```
 
-Then on the failed node (10.0.1.2) we have to stop etcd2 service:
+Then, on the failed node (`10.0.1.2`), stop the etcd2 service:
 
 ```sh
 $ sudo systemctl stop etcd2
 ```
 
-And clean up the `/var/lib/etcd2` directory:
+Clean up the `/var/lib/etcd2` directory:
 
 ```sh
 $ sudo rm -rf /var/lib/etcd2/*
 ```
 
-You have to make sure that this directory exists and empty. It you removed this directory accidentally, you can recreate it with the command below:
+Check that the `/var/lib/etcd2/` directory exists and is empty. If you removed this directory accidentally, you can recreate it with the proper modes by using:
 
 ```sh
 $ sudo systemd-tmpfiles --create /usr/lib64/tmpfiles.d/etcd2.conf
 ```
 
-or with this one:
-
-```sh
-$ sudo install -m 755 -d -o etcd -g etcd /var/lib/etcd2
-```
-
-At the next step we have to reinitialize failed member (please note that 10.0.1.2 is an example IP address, you have to use IP address which corresponds to your failed node):
+Next, reinitialize the failed member. Note that `10.0.1.2` is an example IP address. Use the IP address corresponding to your failed node:
 
 ```sh
 $ etcdctl member add node2 http://10.0.1.2:2380
@@ -145,9 +139,7 @@ ETCD_INITIAL_CLUSTER="52d2c433e31d54526cf3aa660304e8f1=http://10.0.1.1:2380,node
 ETCD_INITIAL_CLUSTER_STATE="existing"
 ```
 
-`etcdctl` will print a tip which we will use to configure new etcd member.
-
-Now we have to create systemd [drop-in] `/run/systemd/system/etcd2.service.d/99-restore.conf` with the options we got on previous step:
+With the new node added, create a systemd [drop-in][drop-in] `/run/systemd/system/etcd2.service.d/99-restore.conf`, replacing the node data with the appropriate information from the output of the `etcdctl member add` command executed in the last step.
 
 ```ini
 [Service]
@@ -159,44 +151,44 @@ Environment="ETCD_INITIAL_CLUSTER=52d2c433e31d54526cf3aa660304e8f1=http://10.0.1
 Environment="ETCD_INITIAL_CLUSTER_STATE=existing"
 ```
 
-**Note:** make sure you've removed double quotes just after `ETCD_INITIAL_CLUSTER=` entry.
+**Note:** Make sure to remove the excess double quotes just after `ETCD_INITIAL_CLUSTER=` entry.
 
-Reload systemd daemon to apply new drop-in:
+Parse the new drop-in:
 
 ```sh
 $ sudo systemctl daemon-reload
 ```
 
-Check whether new [drop-in] is valid:
+Check whether the new [drop-in][drop-in] is valid:
 
 ```sh
 sudo journalctl _PID=1 -e -u etcd2
 ```
 
-And finally if everything is ok start `etcd2` service:
+And finally, if everything is ok start the `etcd2` service:
 
 ```sh
 $ sudo systemctl start etcd2
 ```
 
-You can check whether your cluster is healthy:
+Check cluster health:
 
 ```sh
 $ etcdctl cluster-health
 ```
 
-When your cluster has healthy state that means that etcd successfully wrote cluster configuration into `/var/lib/etcd2` directory. And now it is safe to remove `/run/systemd/system/etcd2.service.d/99-restore.conf` drop-in. Or leave it as is because on next boot it will be cleaned up automatically.
+If your cluster has healthy state, etcd successfully wrote cluster configuration into the `/var/lib/etcd2` directory. Now it is safe to remove the temporary `/run/systemd/system/etcd2.service.d/99-restore.conf` drop-in file.
 
-## etcd Disaster Recovery on CoreOS
+## etcd disaster recovery on CoreOS
 
-When your cluster is totally broken (or all members' IP addresses were changed) and you can not restore its [majority][majority] (quorum) you have to reconfigure your all etcd members from the scratch. This procedure consists of two steps:
+If a cluster is totally broken and [quorum][majority] cannot be restored, all etcd members must be reconfigured from scratch. This procedure consists of two steps:
 
-* Initialize one-member etcd node using the initial [data directory][data-dir]
-* Resize this etcd cluster by adding new etcd member step by step as it explained in the [Change the etcd Cluster Size][change-cluster-size] section.
+* Initialize a one-member etcd cluster using the initial [data directory][data-dir]
+* Resize this etcd cluster by adding new etcd members by following the steps in the [change the etcd cluster size][change-cluster-size] section, above.
 
-This documentation is an adoptation of the official [Disaster recovery][disaster-recovery] guide. Here we use systemd [drop-in] for convenience.
+This document is an adaptation for CoreOS of the official [etcd disaster recovery guide][disaster-recovery], and uses systemd [drop-ins][drop-in] for convenience.
 
-Let's assume you had 3-nodes cluster and none of them is alive. First step we have to do is to stop `etcd2` service on all your member hosts:
+Let's assume a 3-node cluster with no living members. First, stop the `etcd2` service on all the members:
 
 ```sh
 $ sudo systemctl stop etcd2
@@ -204,22 +196,22 @@ $ sudo systemctl stop etcd2
 
 If you have etcd proxy nodes, they should update members list automatically according to the [`--proxy-refresh-interval`][proxy-refresh] configuration option.
 
-Then on one of the *member* node we have to run following command to backup current [data directory][data-dir]:
+Then, on one of the *member* nodes, run the following command to backup the current [data directory][data-dir]:
 
 ```sh
 $ sudo etcdctl backup --data-dir /var/lib/etcd2 --backup-dir /var/lib/etcd2_backup
 ```
 
-After we made the backup we have to inform etcd to start one-member node. Just create `/run/systemd/system/etcd2.service.d/98-force-new-cluster.conf` [drop-in]:
+Now that we've made a backup, we tell etcd to start a one-member cluster. Create the `/run/systemd/system/etcd2.service.d/98-force-new-cluster.conf` [drop-in][drop-in] file with the following contents:
 
 ```ini
 [Service]
 Environment="ETCD_FORCE_NEW_CLUSTER=true"
 ```
 
-Then run `sudo systemctl daemon-reload`, check whether new [drop-in] is valid: `sudo journalctl _PID=1 -e -u etcd2` and if everything is ok start `etcd2` daemon: `sudo systemctl start etcd2`.
+Then run `sudo systemctl daemon-reload`. Check whether the new [drop-in][drop-in] is valid by looking in its journal for errors: `sudo journalctl _PID=1 -e -u etcd2`. If everything is ok, start the `etcd2` daemon: `sudo systemctl start etcd2`.
 
-Check your cluster state:
+Check the cluster state:
 
 ```sh
 $ etcdctl member list
@@ -229,25 +221,22 @@ member e6c2bda2aa1f2dcf is healthy: got healthy result from http://10.0.1.2:2379
 cluster is healthy
 ```
 
-If output messages don't contain any error you have to remove `/run/systemd/system/etcd2.service.d/98-force-new-cluster.conf` drop-ip and reload systemd daemon: `sudo systemctl daemon-reload` (`etcd2` daemon restart is not necessary).
+If the output contains no errors, remove the `/run/systemd/system/etcd2.service.d/98-force-new-cluster.conf` drop-in file, and reload systemd services: `sudo systemctl daemon-reload`. It is not necessary to restart the `etcd2` service after this step.
 
-Next steps are similar to the steps described in the [Change the etcd Cluster Size][change-cluster-size] section but with one exception: you have to remove `/var/lib/etcd2/member` directory as well as `/var/lib/etcd2/proxy` one. **NOTE**: It is strongly recommended to make a backup before you remove these directories:
+The next steps are those described in the [Change etcd cluster size][change-cluster-size] section, with one difference: Remove the `/var/lib/etcd2/member` directory as well as `/var/lib/etcd2/proxy`.
 
-```sh
-$ sudo etcdctl backup --data-dir /var/lib/etcd2 --backup-dir /var/lib/etcd2_backup
-```
 
-[machine-id]: http://www.freedesktop.org/software/systemd/man/machine-id.html
-[drop-in]: /os/using-systemd-drop-in-units.md
+[change-cluster-size]: #change-etcd-cluster-size
 [cloud-config]: https://github.com/coreos/coreos-cloudinit/blob/master/Documentation/cloud-config.md
-[etcd-member-name]: https://github.com/coreos/etcd/blob/master/Documentation/configuration.md#-name
+[data-dir]: https://github.com/coreos/etcd/blob/master/Documentation/configuration.md#-data-dir
+[disaster-recovery]: https://github.com/coreos/etcd/blob/master/Documentation/admin_guide.md#disaster-recovery
+[drop-in]: /os/using-systemd-drop-in-units.md
 [etcd-discovery]: https://github.com/coreos/etcd/blob/master/Documentation/clustering.md#lifetime-of-a-discovery-url
+[etcd-member-name]: https://github.com/coreos/etcd/blob/master/Documentation/configuration.md#-name
 [etcdctl-endpoint]: https://github.com/coreos/etcd/tree/master/etcdctl#--endpoint
 [etcdctl-member-remove]: https://github.com/coreos/etcd/blob/master/Documentation/runtime-configuration.md#remove-a-member
-[locksmith]: https://github.com/coreos/locksmith
 [fleet]: https://github.com/coreos/fleet
+[locksmith]: https://github.com/coreos/locksmith
+[machine-id]: http://www.freedesktop.org/software/systemd/man/machine-id.html
 [majority]: https://github.com/coreos/etcd/blob/master/Documentation/admin_guide.md#fault-tolerance-table
-[data-dir]: https://github.com/coreos/etcd/blob/master/Documentation/configuration.md#-data-dir
-[change-cluster-size]: #change-the-etcd-cluster-size
 [proxy-refresh]: https://github.com/coreos/etcd/blob/master/Documentation/configuration.md#-proxy-refresh-interval
-[disaster-recovery]: https://github.com/coreos/etcd/blob/master/Documentation/admin_guide.md#disaster-recovery


### PR DESCRIPTION
Cleanup edits/rewrite to the entire live-reconf document.
Incremental; second person not entirely removed and can still
stand to be clarified further (with procedure testing) in some
sections.