### PR TITLE
Nit: Fixing VMware spelling

### DIFF
--- a/os/booting-on-vmware.md
+++ b/os/booting-on-vmware.md
@@ -1,6 +1,6 @@
-# Running CoreOS on VMWare
+# Running CoreOS on VMware
 
-These instructions walk through running CoreOS on VMWare Fusion or ESXi. If you are familiar with another VMWare product, you can use these instructions as a starting point.
+These instructions walk through running CoreOS on VMware Fusion or ESXi. If you are familiar with another VMware product, you can use these instructions as a starting point.
 
 ## Running the VM
 
@@ -38,11 +38,11 @@ CoreOS is released into stable, alpha and beta channels. Releases to each channe
 
 [release notes]: https://coreos.com/releases/
 
-### Booting with VMWare Fusion
+### Booting with VMware Fusion
 
-After downloading the VMWare OVA image for your selected channel, open the `coreos_production_vmware_ova.ova` file to create a VM.
+After downloading the VMware OVA image for your selected channel, open the `coreos_production_vmware_ova.ova` file to create a VM.
 
-### Booting with VMWare ESXi
+### Booting with VMware ESXi
 
 Use the vSphere Client to deploy the VM as follows:
 
@@ -59,14 +59,14 @@ The last step uploads the files to the ESXi datastore and registers the new VM. 
 
 *NB: These instructions were tested with an ESXi v5.5 host.*
 
-### Booting with VMWare Workstation 12
+### Booting with VMware Workstation 12
 
-Run VMWare Workstation GUI:
+Run VMware Workstation GUI:
 
 1. In the menu, click `File` > `Open...`
 2. In the wizard, specify the location of the OVA template downloaded earlier
 3. Name your VM, then click `Import`
-4. (Press `Retry` *if* VMWare Workstation raises an "OVF specification" warning)
+4. (Press `Retry` *if* VMware Workstation raises an "OVF specification" warning)
 5. Edit VM settings if necessary
 6. Start your CoreOS VM
 
@@ -76,7 +76,7 @@ Cloud-config data can be passed into a VM by attaching a [config-drive][config-d
 
 The config-drive standard was originally an OpenStack feature, which is why you'll see the string `openstack` in a few bits of configuration. This naming convention is retained, although CoreOS supports config-drive on all platforms.
 
-This example will configure CoreOS components: etcd2 and fleetd. `$private_ipv4` and `$public_ipv4` are supported on VMWare in CoreOS releases 801.0.0 and greater, and **only** when you explicitly configure interfaces' roles to `private` or `public` in [Guestinfo][guestinfo] for each VMWare instance.
+This example will configure CoreOS components: etcd2 and fleetd. `$private_ipv4` and `$public_ipv4` are supported on VMware in CoreOS releases 801.0.0 and greater, and **only** when you explicitly configure interfaces' roles to `private` or `public` in [Guestinfo][guestinfo] for each VMware instance.
 
 ```yaml
 #cloud-config
@@ -104,31 +104,31 @@ coreos:
 
 For details on the options available with cloud-config, see the [cloud-config guide][cloud-config guide].
 
-## VMWare Guestinfo Interface
+## VMware Guestinfo Interface
 
 ### Setting Guestinfo Options
 
-The VMWare guestinfo interface is an alternative to using a config-drive for VM configuration. Guestinfo properties are stored in the VMX file, or in the VMX representation in host memory. These properties are available to the VM at boot time. Within the VMX, the names of these properties are prefixed with `guestinfo.`. Guestinfo settings can be injected into VMs in one of four ways:
+The VMware guestinfo interface is an alternative to using a config-drive for VM configuration. Guestinfo properties are stored in the VMX file, or in the VMX representation in host memory. These properties are available to the VM at boot time. Within the VMX, the names of these properties are prefixed with `guestinfo.`. Guestinfo settings can be injected into VMs in one of four ways:
 
-* Configure guestinfo in the OVF for deployment. Software like [vcloud director][vcloud director] manipulates OVF descriptors for guest configuration. For details, check out this VMWare blog post about [Self-Configuration and the OVF Environment][ovf-selfconfig].
+* Configure guestinfo in the OVF for deployment. Software like [vcloud director][vcloud director] manipulates OVF descriptors for guest configuration. For details, check out this VMware blog post about [Self-Configuration and the OVF Environment][ovf-selfconfig].
 
-* Set guestinfo keys and values from the CoreOS guest itself, by using a vmwaretools command like:
+* Set guestinfo keys and values from the CoreOS guest itself, by using a VMware Tools command like:
 
 ```sh
 /usr/share/oem/bin/vmtoolsd --cmd "info-set guestinfo.<variable> <value>"
 ```
 
-* Guestinfo keys and values can be set from a VMWare Service Console, using the `setguestinfo` subcommand:
+* Guestinfo keys and values can be set from a VMware Service Console, using the `setguestinfo` subcommand:
 
 ```sh
 vmware-cmd /vmfs/volumes/[...]/<VMNAME>/<VMNAME>.vmx setguestinfo guestinfo.<property> <value>
 ```
 
-* You can manually modify the VMX and reload it on the VMWare Workstation, ESXi host, or in vCenter.
+* You can manually modify the VMX and reload it on the VMware Workstation, ESXi host, or in vCenter.
 
-Guestinfo configuration set via the VMWare API or with `vmtoolsd` from within the CoreOS guest itself are stored in VM process memory and are lost on VM shutdown or reboot.
+Guestinfo configuration set via the VMware API or with `vmtoolsd` from within the CoreOS guest itself are stored in VM process memory and are lost on VM shutdown or reboot.
 
-[This blog post][vmware-use-guestinfo] has some useful details about the guestinfo interface, while Robert Labrie's blog provides a practicum specific to [using VMWare guestinfo to configure CoreOS VMs][labrie-guestinfo].
+[This blog post][vmware-use-guestinfo] has some useful details about the guestinfo interface, while Robert Labrie's blog provides a practicum specific to [using VMware guestinfo to configure CoreOS VMs][labrie-guestinfo].
 
 ### Guestinfo Example
 
@@ -146,7 +146,7 @@ guestinfo.interface.0.dhcp = "no"
 guestinfo.interface.0.ip.0.address = "192.168.178.97/24"
 ```
 
-The CoreOS OVA image contains the VMWare tools, and a OEM cloud-config which executes `coreos-cloudinit` with the `--oem=vmware` option. This option automatically sets the additional `--from-vmware-guestinfo` and `--convert-netconf=vmware` flags. Given the `guestinfo.*` values above and these option flags, `coreos-cloudinit` will generate the following systemd network unit:
+The CoreOS OVA image contains the VMware tools, and a OEM cloud-config which executes `coreos-cloudinit` with the `--oem=vmware` option. This option automatically sets the additional `--from-vmware-guestinfo` and `--convert-netconf=vmware` flags. Given the `guestinfo.*` values above and these option flags, `coreos-cloudinit` will generate the following systemd network unit:
 
 ```
 [Match]
@@ -194,14 +194,14 @@ ssh_authorized_keys:
  - ssh-rsa mypubkey
 ```
 
-Refer to the [VMWare guestinfo variables documentation][vmware guestinfo] for a full list of supported properties.
+Refer to the [VMware guestinfo variables documentation][VMware guestinfo] for a full list of supported properties.
 
 ## Logging in
 
-Networking can take some time to start under VMWare. Once it does, press enter a few times at the login prompt and
+Networking can take some time to start under VMware. Once it does, press enter a few times at the login prompt and
 you should see an IP address printed on the console:
 
-![VMWare IP Address](img/vmware-ip.png)
+![VMware IP Address](img/vmware-ip.png)
 
 In this case the IP is `10.0.1.81`.
 
@@ -222,7 +222,7 @@ Now that you have a machine booted, it's time to explore. Check out the [CoreOS 
 [config-drive]: https://github.com/coreos/coreos-cloudinit/blob/master/Documentation/config-drive.md
 [cloud-config guide]: https://github.com/coreos/coreos-cloudinit/blob/master/Documentation/cloud-config.md
 [coreos-cloudinit]: https://github.com/coreos/coreos-cloudinit
-[vmware guestinfo]: https://github.com/coreos/coreos-cloudinit/blob/master/Documentation/vmware-guestinfo.md
+[VMware guestinfo]: https://github.com/coreos/coreos-cloudinit/blob/master/Documentation/vmware-guestinfo.md
 [vcloud director]: http://blogs.vmware.com/vsphere/2012/06/leveraging-vapp-vm-custom-properties-in-vcloud-director.html
 [ovf-selfconfig]: http://blogs.vmware.com/vapp/2009/07/selfconfiguration-and-the-ovf-environment.html
 [vmware-use-guestinfo]: http://blog-lrivallain.rhcloud.com/2014/08/15/vmware-use-guestinfo-variables-to-customize-guest-os/


### PR DESCRIPTION
Sorry for Nit, but VMware is spelled with lower-case "w" 