### PR TITLE
os: re-add rootfstype command line flag

### DIFF
--- a/os/booting-with-pxe.md
+++ b/os/booting-with-pxe.md
@@ -16,6 +16,8 @@ If you need suggestions on how to set a server up, check out guides for [Debian]
 
 When configuring the CoreOS pxelinux.cfg there are a few kernel options that may be useful but all are optional.
 
+- **rootfstype=tmpfs**: Use tmpfs for the writable root filesystem. This is the default behavior.
+- **rootfstype=btrfs**: Use btrfs in RAM for the writable root filesystem. The filesystem will consume more RAM as it grows, up to a max of 50%. The limit isn't currently configurable.
 - **root**: Use a local filesystem for root instead of one of two in-ram options above. The filesystem must be formatted in advance but may be completely blank, it will be initialized on boot. The filesystem may be specified by any of the usual ways including device, label, or UUID; e.g: `root=/dev/sda1`, `root=LABEL=ROOT` or `root=UUID=2c618316-d17a-4688-b43b-aa19d97ea821`.
 - **sshkey**: Add the given SSH public key to the `core` user's authorized_keys file. Replace the example key below with your own (it is usually in `~/.ssh/id_rsa.pub`)
 - **console**: Enable kernel output and a login prompt on a given tty. The default, `tty0`, generally maps to VGA. Can be used multiple times, e.g. `console=tty0 console=ttyS0`


### PR DESCRIPTION
Fixes https://github.com/coreos/docs/issues/793.