### PR TITLE
docs: Add description of how toolbox runs

### DIFF
--- a/os/install-debugging-tools.md
+++ b/os/install-debugging-tools.md
@@ -45,6 +45,20 @@ write_files:
       TOOLBOX_USER=root
 ```
 
+## Under the hood
+
+Behind the scenes, `toolbox` downloads, prepares and exports the image 
+you specify (or the default `fedora` image), then creates a container 
+from that extracted image by calling `systemd-nspawn`.  The exported 
+image is retained in 
+`/var/lib/toolbox/[username]-[image name]-[image tag]`, e.g. the default 
+image run by the `core` user is at `/var/lib/toolbox/core-fedora-latest`.  
+This means two important things:
+
+* Changes made inside the container will persist between sessions
+* The container filesystem will take up space on disk (a few hundred MiB 
+for the default `fedora` container)
+
 ## SSH directly into a toolbox
 
 Advanced users can SSH directly into a toolbox by setting up an `/etc/passwd` entry:


### PR DESCRIPTION
Describe how toolbox creates and runs the container filesystem, and what
that means for persistence of the container.