### PR TITLE
os: added note to manual update when disabling update-engine

### DIFF
--- a/os/update-strategies.md
+++ b/os/update-strategies.md
@@ -119,6 +119,19 @@ $ update_engine_client -check_for_update
 [0123/220706:INFO:update_engine_client.cc(245)] Initiating update check and install.
 ```
 
+### Running Manual Update with update-engine disabled
+
+If you disabled update-engine.service and wish to run the manual update, you must first enable the update-service to run the update_engine_client:
+
+```
+$ systemctl start update-engine.service
+$ update_engine_client -check_for_update
+```
+
+After the update you must comment out or remove the disabling of the update-engine.service for this first reboot. This allows for the update-engine to mark the new active partition, being your updated one, as a successful boot. If you do not run update-engine upon the first reboot, there is a chance that your machine will mark the new active partition as a failure and revert back to the passive partition (being the previous version) on the next reboot of the machine. Once rebooted you are able to again stop the update-engine and uncomment or add the update-engine.service disabling in your cloud-config.yml.
+
+To avoid this process, a potential option is to use a Service for disabling update-engine and locksmithd using the [Systemd OnCalendar setting](oncalendar-option) which will disable the update-engine.service and locksmithd.service in a particular time period after reboot.
+
 ## Auto-updates with a maintenance window
 
 Locksmith supports maintenance windows in addition to the reboot strategies mentioned earlier. Maintenance windows define a window of time during which a reboot can occur. These operate in addition to reboot strategies, so if the machine has a maintenance window and requires a reboot lock, the machine will only reboot when it has the lock during that window.
@@ -137,3 +150,4 @@ For more information about the supported syntax, refer to the [Locksmith documen
 
 [rollback]: manual-rollbacks.md
 [reboot-windows]: https://github.com/coreos/locksmith#reboot-windows
+[oncalendar-option]:  https://coreos.com/os/docs/latest/scheduling-tasks-with-systemd-timers.html


### PR DESCRIPTION
os/update-strategies.md: Added a note to warn of potential issues in a manual update upon disabling update-engine.service after line #122

After experiencing issues after reboot noted in the issue coreos/bugs#1189, I had time to sit down and try to diagnose the issue.  I brought this to the attention of Brian Harrington as OSCON, he seemed to confirm the suspicion that with update-engine disabled upon reboot, the updates would eventually revert back to the passive partition after the following reboot.

IE:
update installed manually, reboot, see version NEW.x, generic reboot (for no specific reason), see version OLD.x

I was hoping to add this documentation to inform anyone else that are falling into the same trap.  If merged, I hope to add a Systemd Service File that includes an example of the 'OnCalendar' as mentioned above to shut of update-engine/locksmithd on a designated time after reboot to avoid issues like this in the future.

Thanks,
Jason Cameron
