### PR TITLE
quay-enterprise/: Update pulls with image version tags

### DIFF
--- a/quay-enterprise/build-support.md
+++ b/quay-enterprise/build-support.md
@@ -31,7 +31,7 @@ The build worker is currently in beta. To gain access to its repository, please 
 Once given access, pull down the latest copy of the image just like any other:
 
 ```sh
-docker pull quay.io/coreos/registry-build-worker:latest
+docker pull quay.io/coreos/registry-build-worker:v1.16.1
 ```
 
 ### Run the build worker image
@@ -48,7 +48,7 @@ Use the environment variable `SERVER` to tell the worker how to communicate with
 Here's what the full command looks like:
 
 ```sh
-docker run --restart on-failure -e SERVER=wss://myenterprise.host -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/registry-build-worker:latest
+docker run --restart on-failure -e SERVER=wss://myenterprise.host -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/registry-build-worker:v1.16.1
 ```
 
 When the container starts, each build worker will auto-register with the Enterprise Registry and start building containers once a job triggered and it is assigned to a worker.

--- a/quay-enterprise/clair.md
+++ b/quay-enterprise/clair.md
@@ -27,7 +27,7 @@ The configuration string for this test database is `postgresql://postgres@{DOCKE
 Pull the security-enabled Clair image:
 
 ```
-docker pull quay.io/coreos/clair-jwt:latest
+docker pull quay.io/coreos/clair-jwt:v1.2.2
 ```
 
 ### Make a configuration directory for Clair
@@ -218,7 +218,7 @@ To configure Clair to run under TLS, a few additional steps are required:
 Execute the following command to run Clair:
 
 ```
-docker run --restart=always -p 6060:6060 -p 6061:6061 -v /path/to/clair/config/directory:/config quay.io/coreos/clair-jwt
+docker run --restart=always -p 6060:6060 -p 6061:6061 -v /path/to/clair/config/directory:/config quay.io/coreos/clair-jwt:v1.2.2
 ```
 
 Output similar to the following will be seen on success:

--- a/quay-enterprise/initial-setup.md
+++ b/quay-enterprise/initial-setup.md
@@ -28,7 +28,7 @@ sudo docker run -d -p 6379:6379 quay.io/quay/redis
 
 ## Downloading the enterprise registry image
 
-After signing up you will receive a `.dockercfg` file containing your credentials to the `quay.io/coreos/registry` repository. Save this file to your CoreOS machine in `/home/core/.dockercfg` and `/root/.dockercfg`. You should now be able to execute `docker pull quay.io/coreos/registry` to download the container.
+After signing up you will receive a `.dockercfg` file containing your credentials to the `quay.io/coreos/registry` repository. Save this file to your CoreOS machine in `/home/core/.dockercfg` and `/root/.dockercfg`. You should now be able to execute `docker pull quay.io/coreos/registry:v1.16.1` to download the container.
 
 ## Setting up the directories
 
@@ -44,7 +44,7 @@ mkdir config
 Run the following command, replacing `/local/path/to/the/config/directory` and `/local/path/to/the/storage/directory` with the absolute paths to the directories created above:
 
 ```
-sudo docker run --restart=always -p 443:443 -p 80:80 --privileged=true -v /local/path/to/the/config/directory:/conf/stack -v /local/path/to/the/storage/directory:/datastorage -d quay.io/coreos/registry
+sudo docker run --restart=always -p 443:443 -p 80:80 --privileged=true -v /local/path/to/the/config/directory:/conf/stack -v /local/path/to/the/storage/directory:/datastorage -d quay.io/coreos/registry:v1.16.1
 ```
 
 <img src="img/db-setup-full.png" class="img-center" alt="Enterprise Registry Setup Screen"/>


### PR DESCRIPTION
Upstream of bulk of https://github.com/coreos-inc/tectonic-pages/pull/187,
minus the change in coreos-inc/tectonic repo (in https://github.com/coreos-inc/tectonic/pull/229).