### PR TITLE
Update registry-authentication.md

### DIFF
--- a/os/registry-authentication.md
+++ b/os/registry-authentication.md
@@ -1,8 +1,8 @@
 # Using authentication for a registry
 
-A json file `.dockercfg` is generated in your home directory on `docker login`. It holds authentication information for a public or private Docker registry. This `.dockercfg` can be reused in other home directories to authenticate. One way to do this is using Cloud-Config which is discussed more below. If you want to populate these values without running Docker login, the auth token is a base64 encoded string: `base64(<username>:<password>)`.
+A json file `.docker/config.json` is generated in your home directory on `docker login`. It holds authentication information for a public or private Docker registry. This `.docker/config.json` can be reused in other home directories to authenticate. One way to do this is using Cloud-Config which is discussed more below. If you want to populate these values without running Docker login, the auth token is a base64 encoded string: `base64(<username>:<password>)`.
 
-## The .dockercfg file
+## The $HOME/.docker/config.json file
 
 Here's what an example looks like with credentials for Docker's public index and a private index:
 
@@ -45,7 +45,7 @@ Since each machine in your cluster is going to have to pull images, cloud-config
 ```yaml
 #cloud-config
 write_files:
-    - path: /home/core/.dockercfg
+    - path: /home/core/.docker/config.json
       owner: core:core
       permissions: '0644'
       content: |


### PR DESCRIPTION
Sorry if this doesn't apply to CoreOS but the official Docker client stores data in this file and this page turn up when you search for docker login credentials.