### PR TITLE
Add systemd-timesyncd restart to cloud-config snippet

### DIFF
--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -156,6 +156,11 @@ NTP time sources can be set in `timesyncd.conf` with a cloud-config snippet like
 
 ```yaml
 #cloud-config
+coreos:
+  units:
+    - name: systemd-timesyncd.service
+      command: restart
+
 write_files:
   - path: /etc/systemd/timesyncd.conf
     content: |


### PR DESCRIPTION
`systemd-timesyncd` starts before `coreos-cloudinit`. It needs to be restarted in cloud-config in order to apply changed NTP time sources.
