### PR TITLE
quay-enterprise/: Update quay container version to current 1.16.3

### DIFF
--- a/quay-enterprise/build-support.md
+++ b/quay-enterprise/build-support.md
@@ -31,7 +31,7 @@ The build worker is currently in beta. To gain access to its repository, please 
 Once given access, pull down the latest copy of the image just like any other:
 
 ```sh
-docker pull quay.io/coreos/registry-build-worker:v1.16.1
+docker pull quay.io/coreos/registry-build-worker:v1.16.3
 ```
 
 ### Run the build worker image
@@ -48,7 +48,7 @@ Use the environment variable `SERVER` to tell the worker how to communicate with
 Here's what the full command looks like:
 
 ```sh
-docker run --restart on-failure -e SERVER=wss://myenterprise.host -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/registry-build-worker:v1.16.1
+docker run --restart on-failure -e SERVER=wss://myenterprise.host -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/registry-build-worker:v1.16.3
 ```
 
 When the container starts, each build worker will auto-register with the Enterprise Registry and start building containers once a job triggered and it is assigned to a worker.

--- a/quay-enterprise/initial-setup.md
+++ b/quay-enterprise/initial-setup.md
@@ -28,7 +28,7 @@ sudo docker run -d -p 6379:6379 quay.io/quay/redis
 
 ## Downloading the enterprise registry image
 
-After signing up you will receive a `.dockercfg` file containing your credentials to the `quay.io/coreos/registry` repository. Save this file to your CoreOS machine in `/home/core/.dockercfg` and `/root/.dockercfg`. You should now be able to execute `docker pull quay.io/coreos/registry:v1.16.1` to download the container.
+After signing up you will receive a `.dockercfg` file containing your credentials to the `quay.io/coreos/registry` repository. Save this file to your CoreOS machine in `/home/core/.dockercfg` and `/root/.dockercfg`. You should now be able to execute `docker pull quay.io/coreos/registry:v1.16.3` to download the container.
 
 ## Setting up the directories
 
@@ -44,7 +44,7 @@ mkdir config
 Run the following command, replacing `/local/path/to/the/config/directory` and `/local/path/to/the/storage/directory` with the absolute paths to the directories created above:
 
 ```
-sudo docker run --restart=always -p 443:443 -p 80:80 --privileged=true -v /local/path/to/the/config/directory:/conf/stack -v /local/path/to/the/storage/directory:/datastorage -d quay.io/coreos/registry:v1.16.1
+sudo docker run --restart=always -p 443:443 -p 80:80 --privileged=true -v /local/path/to/the/config/directory:/conf/stack -v /local/path/to/the/storage/directory:/datastorage -d quay.io/coreos/registry:v1.16.3
 ```
 
 <img src="img/db-setup-full.png" class="img-center" alt="Enterprise Registry Setup Screen"/>


### PR DESCRIPTION
Ref https://github.com/coreos-inc/tectonic-pages/pull/211

Proposed TODO: These should be version "latest", as they are in the
quay-enterprise yaml owned by the tectonic team, see
https://github.com/coreos-inc/tectonic/commit/4f15f8c58321ddf433ceb6ba3838875db2735353#diff-98914fd9e6d06eab312a20550c5fe2df