### PR TITLE
systemd runs 'docker kill ecs-agent' before containerd is up

### DIFF
--- a/os/booting-on-ecs.md
+++ b/os/booting-on-ecs.md
@@ -24,7 +24,7 @@ coreos:
        Description=AWS ECS Agent
        Documentation=https://docs.aws.amazon.com/AmazonECS/latest/developerguide/
        Requires=docker.socket
-       After=docker.socket
+       After=docker.service
 
        [Service]
        Environment=ECS_CLUSTER=your_cluster_name


### PR DESCRIPTION
This causes ecs-agent.service to fail on boot.

root@ip-172-19-68-72:~# systemctl status ecs-agent.service
● ecs-agent.service - AWS ECS Agent
   Loaded: loaded (/etc/systemd/system/ecs-agent.service; enabled; vendor preset: enabled)
   Active: activating (auto-restart) (Result: timeout) since Thu 2016-07-07 19:55:21 UTC; 1s ago
     Docs: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/
  Process: 1446 ExecStartPre=/usr/bin/docker pull amazon/amazon-ecs-agent:${ECS_VERSION} (code=exited, status=0/SUCCESS)
  Process: 1437 ExecStartPre=/usr/bin/docker rm ecs-agent (code=exited, status=0/SUCCESS)
  Process: 713 ExecStartPre=/usr/bin/docker kill ecs-agent (code=exited, status=2)
    Tasks: 0
   Memory: 0B
      CPU: 0

root@ip-172-19-68-72:~# ps -ef | grep docker
root       752     1  0 20:02 ?        00:00:00 /usr/bin/docker kill ecs-agent
root      1015     1  0 20:03 ?        00:00:00 /usr/bin/docker daemon -H unix:///var/run/docker.sock
root      1024  1015  0 20:03 ?        00:00:00 docker-containerd -l /var/run/docker/libcontainerd/docker-containerd.sock --runtime docker-runc --start-timeout 2m

The pids don't match; I know.  I  tried several reboots.
