### PR TITLE
Update auths of docker config

### DIFF
--- a/os/registry-authentication.md
+++ b/os/registry-authentication.md
@@ -10,17 +10,16 @@ Here's what an example looks like with credentials for Docker's public index and
 
 ```json
 {
-  "quay.io": {
-    "auth": "xXxXxXxXxXx=",
-    "email": "username@example.com"
-  },
-  "https://index.docker.io/v1/": {
-    "auth": "xXxXxXxXxXx=",
-    "email": "username@example.com"
-  },
-  "https://index.example.com": {
-    "auth": "XxXxXxXxXxX=",
-    "email": "username@example.com"
+  "auths": {
+    "quay.io": {
+      "auth": "xXxXxXxXxXx="
+    },
+    "https://index.docker.io/v1/": {
+      "auth": "xXxXxXxXxXx="
+    },
+    "https://index.example.com": {
+      "auth": "XxXxXxXxXxX="
+    }
   }
 }
 ```
@@ -49,20 +48,19 @@ Since each machine in your cluster is going to have to pull images, cloud-config
 write_files:
     - path: /home/core/.docker/config.json
       owner: core:core
-      permissions: '0644'
+      permissions: '0600'
       content: |
         {
-          "quay.io": {
-            "auth": "xXxXxXxXxXx=",
-            "email": "username@example.com"
-          },
-          "https://index.docker.io/v1/": {
-            "auth": "xXxXxXxXxXx=",
-            "email": "username@example.com"
-          },
-          "https://index.example.com": {
-            "auth": "XxXxXxXxXxX=",
-            "email": "username@example.com"
+          "auths": {
+            "quay.io": {
+              "auth": "xXxXxXxXxXx="
+            },
+            "https://index.docker.io/v1/": {
+              "auth": "xXxXxXxXxXx="
+            },
+            "https://index.example.com": {
+              "auth": "XxXxXxXxXxX="
+            }
           }
         }
 ```


### PR DESCRIPTION
Current stable CoreOS works with this configuration. I also changed the
permissions of the config file to reflect what docker itself uses.

Proof

You can see that the config tests are expecting this format. I couldn't
find any better proof. I tested it myself with CoreOS stable (1068.8.0)
and it works.

https://github.com/docker/docker/blob/v1.10.3/cliconfig/config_test.go#L262