### PR TITLE
iSCSI Docs (First Iteration)

### DIFF
--- a/os/iscsi.md
+++ b/os/iscsi.md
@@ -1,0 +1,54 @@
+# iSCSI on CoreOS
+
+CoreOS has integrated support for mounting iSCSI devices. In order to configure it, do the following:
+
+## Configure the CoreOS iSCSI initiator name
+
+iSCSI clients each have a unique initiator name. CoreOS generates a unique
+initiator name on each install and stores it in
+/etc/iscsi/initiatorname.iscsi. This may be replaced if necessary.
+
+## Configure the global iSCSI credentials
+
+If all iSCSI mounts on a CoreOS system use the same credentials, these may
+be configured locally by editing /etc/iscsi/iscsid.conf and setting the
+node.session.auth.username and node.session.auth.password fields. If the
+iSCSI target is configured to support mutual authentication (allowing the
+initiator to verify that it is speaking to the correct client), these should
+be set in node.session.auth.username_in and node.session.auth.password_in.
+
+## Start the iSCSI daemon
+
+systemctl start iscsid
+
+## Discover available iSCSI targets
+
+Run
+
+iscsiadm -m discovery -t sendtargets -p target_ip:port
+
+## To provide target-specific credentials
+
+You can replace the global credentials with target-specific credentials by running:
+
+iscsiadm -m node --targetname=targetname --op-update --name=node.session.auth.username --value=username
+
+iscsiadm -m node --targetname=targetname --op-update --name=node.session.auth.password --value=password
+
+## Log into an iSCSI target
+
+iscsiadm -m node --login
+
+will log into all discovered targets. To log into a specific target:
+
+iscsiadm -m node --targetname=targetname --login
+
+## Enable automatic iSCSI login at boot
+
+If you want to connect to iSCSI targets automatically at boot, run
+
+systemctl enable iscsid
+
+## Mounting iSCSI targets
+
+See https://coreos.com/os/docs/latest/mounting-storage.html

--- a/os/iscsi.md
+++ b/os/iscsi.md
@@ -1,54 +1,64 @@
 # iSCSI on CoreOS
 
-CoreOS has integrated support for mounting iSCSI devices. In order to configure it, do the following:
+[iSCSI][iscsi-wiki] is a protocol which provides block-level access to storage devices over IP.  This allows applications to treat remote storage devices as if they were local disks.  iSCSI handles taking requests from clients and carrying them out on the remote SCSI devices.
+
+CoreOS has integrated support for mounting devices. In order to configure it, do the following:
 
 ## Configure the CoreOS iSCSI initiator name
 
-iSCSI clients each have a unique initiator name. CoreOS generates a unique
-initiator name on each install and stores it in
-/etc/iscsi/initiatorname.iscsi. This may be replaced if necessary.
+iSCSI clients each have a unique initiator name. CoreOS generates a unique initiator name on each install and stores it in `/etc/iscsi/initiatorname.iscsi`. This may be replaced if necessary.
 
 ## Configure the global iSCSI credentials
 
-If all iSCSI mounts on a CoreOS system use the same credentials, these may
-be configured locally by editing /etc/iscsi/iscsid.conf and setting the
-node.session.auth.username and node.session.auth.password fields. If the
-iSCSI target is configured to support mutual authentication (allowing the
-initiator to verify that it is speaking to the correct client), these should
-be set in node.session.auth.username_in and node.session.auth.password_in.
+If all iSCSI mounts on a CoreOS system use the same credentials, these may be configured locally by editing `/etc/iscsi/iscsid.conf` and setting the `node.session.auth.username` and `node.session.auth.password` fields. If the iSCSI target is configured to support mutual authentication (allowing the initiator to verify that it is speaking to the correct client), these should be set in `node.session.auth.username_in` and `node.session.auth.password_in`.
 
 ## Start the iSCSI daemon
 
+```
 systemctl start iscsid
+```
 
 ## Discover available iSCSI targets
 
 Run
 
+```
 iscsiadm -m discovery -t sendtargets -p target_ip:port
+```
 
 ## To provide target-specific credentials
 
 You can replace the global credentials with target-specific credentials by running:
 
+```
 iscsiadm -m node --targetname=targetname --op-update --name=node.session.auth.username --value=username
 
 iscsiadm -m node --targetname=targetname --op-update --name=node.session.auth.password --value=password
+```
 
 ## Log into an iSCSI target
 
+```
 iscsiadm -m node --login
+```
 
 will log into all discovered targets. To log into a specific target:
 
+```
 iscsiadm -m node --targetname=targetname --login
+```
 
 ## Enable automatic iSCSI login at boot
 
 If you want to connect to iSCSI targets automatically at boot, run
 
+```
 systemctl enable iscsid
+```
 
 ## Mounting iSCSI targets
 
-See https://coreos.com/os/docs/latest/mounting-storage.html
+See the [mounting storage docs][mounting-storage] for an example.
+
+[iscsi-wiki]: https://en.wikipedia.org/wiki/ISCSI
+[mounting-storage]: mounting-storage.md

--- a/os/iscsi.md
+++ b/os/iscsi.md
@@ -1,16 +1,22 @@
 # iSCSI on CoreOS
 
-[iSCSI][iscsi-wiki] is a protocol which provides block-level access to storage devices over IP.  This allows applications to treat remote storage devices as if they were local disks.  iSCSI handles taking requests from clients and carrying them out on the remote SCSI devices.
+[iSCSI][iscsi-wiki] is a protocol which provides block-level access to storage devices over IP.
+This allows applications to treat remote storage devices as if they were local disks.
+iSCSI handles taking requests from clients and carrying them out on the remote SCSI devices.
 
-CoreOS has integrated support for mounting devices. In order to configure it, do the following:
+CoreOS has integrated support for mounting devices.
+In order to configure it, do the following:
 
 ## Configure the CoreOS iSCSI initiator name
 
-iSCSI clients each have a unique initiator name. CoreOS generates a unique initiator name on each install and stores it in `/etc/iscsi/initiatorname.iscsi`. This may be replaced if necessary.
+iSCSI clients each have a unique initiator name.
+CoreOS generates a unique initiator name on each install and stores it in `/etc/iscsi/initiatorname.iscsi`.
+This may be replaced if necessary.
 
 ## Configure the global iSCSI credentials
 
-If all iSCSI mounts on a CoreOS system use the same credentials, these may be configured locally by editing `/etc/iscsi/iscsid.conf` and setting the `node.session.auth.username` and `node.session.auth.password` fields. If the iSCSI target is configured to support mutual authentication (allowing the initiator to verify that it is speaking to the correct client), these should be set in `node.session.auth.username_in` and `node.session.auth.password_in`.
+If all iSCSI mounts on a CoreOS system use the same credentials, these may be configured locally by editing `/etc/iscsi/iscsid.conf` and setting the `node.session.auth.username` and `node.session.auth.password` fields.
+If the iSCSI target is configured to support mutual authentication (allowing the initiator to verify that it is speaking to the correct client), these should be set in `node.session.auth.username_in` and `node.session.auth.password_in`.
 
 ## Start the iSCSI daemon
 
@@ -23,23 +29,29 @@ systemctl start iscsid
 To discover targets, run:
 
 ```
-$ iscsiadm -m discovery -t sendtargets -p target_ip:port
+$ iscsiadm -m discovery -t sendtargets -p target_ip:target_port
 ```
 
-## To provide target-specific credentials
+## Provide target-specific credentials
 
-You can replace the global credentials with target-specific credentials by running:
-
-```
-$ iscsiadm -m node --targetname=targetname --op-update --name=node.session.auth.username --value=username
-$ iscsiadm -m node --targetname=targetname --op-update --name=node.session.auth.password --value=password
-```
-
-`targetname`, `username`, and `password` are specific to you, not literal strings. For example:
+For each unique `--targetname`, first enter the username:
 
 ```
-$ iscsiadm -m node --targetname=custom_target --op-update --name=node.session.auth.username --value=some_username
-$ iscsiadm -m node --targetname=custom_target --op-update --name=node.session.auth.password --value=secret_password
+$ iscsiadm -m node \
+  --targetname=custom_target \
+  --op update \
+  --name=node.session.auth.username \
+  --value=my_username
+```
+
+And then the password:
+
+```
+$ iscsiadm -m node \
+  --targetname=custom_target \
+  --op update \
+  --name=node.session.auth.password \
+  --value=my_secret_passphrase
 ```
 
 ## Log into an iSCSI target
@@ -53,24 +65,60 @@ $ iscsiadm -m node --login
 Then, to log into a specific target use:
 
 ```
-$ iscsiadm -m node --targetname=targetname --login
-```
-
-The value for `targetname` is unique to your setup. For example:
-
-```
 $ iscsiadm -m node --targetname=custom_target --login
 ```
 
 ## Enable automatic iSCSI login at boot
 
-If you want to connect to iSCSI targets automatically at boot, run
+If you want to connect to iSCSI targets automatically at boot you first need to enable the systemd service.
+
+### Manual
+
+Running this command (after the above steps) will enable to iscsid systemd unit, starting the service on boot.
 
 ```
 $ systemctl enable iscsid
 ```
 
-<!-- TODO: add a cloud-config or ignition example! -->
+### Via cloud-config and ignition
+
+To create and enable the iscsid service automatically using cloud-config and ignition, edit the following lines in the file `/etc/iscsi/iscsid.conf` to match:
+
+/etc/iscsi/iscsid.conf
+<!-- TODO: It's inclear based on documentation what the actual first line of this doc snippet should be.
+     This is a best guess based on docs I've read, the rest I'm pretty certain of.
+     I know we want to do discovery in this file, just not sure if that line accomplished the task. -->
+```
+isns.address = host_ip
+isns.port = host_port
+node.session.auth.username = my_username
+node.session.auth.password = my_secret_password
+discovery.sendtargets.auth.username = my_username
+discovery.sendtargets.auth.password = my_secret_password
+```
+
+Enable the service with the following cloud-config and ignition configs:
+
+cloud-config:
+```
+coreos:
+    units:
+        - name: "iscsid.service"
+          command: "start"
+```
+
+ignition config:
+```
+{
+  "ignition": { "version": "2.0.0" },
+  "systemd": {
+    "units": [{
+      "name": "iscsid.service",
+      "enable": true,
+    }]
+  }
+}
+```
 
 ## Mounting iSCSI targets
 

--- a/os/iscsi.md
+++ b/os/iscsi.md
@@ -20,10 +20,10 @@ systemctl start iscsid
 
 ## Discover available iSCSI targets
 
-Run
+To discover targets, run:
 
 ```
-iscsiadm -m discovery -t sendtargets -p target_ip:port
+$ iscsiadm -m discovery -t sendtargets -p target_ip:port
 ```
 
 ## To provide target-specific credentials
@@ -31,21 +31,35 @@ iscsiadm -m discovery -t sendtargets -p target_ip:port
 You can replace the global credentials with target-specific credentials by running:
 
 ```
-iscsiadm -m node --targetname=targetname --op-update --name=node.session.auth.username --value=username
+$ iscsiadm -m node --targetname=targetname --op-update --name=node.session.auth.username --value=username
+$ iscsiadm -m node --targetname=targetname --op-update --name=node.session.auth.password --value=password
+```
 
-iscsiadm -m node --targetname=targetname --op-update --name=node.session.auth.password --value=password
+`targetname`, `username`, and `password` are specific to you, not literal strings. For example:
+
+```
+$ iscsiadm -m node --targetname=custom_target --op-update --name=node.session.auth.username --value=some_username
+$ iscsiadm -m node --targetname=custom_target --op-update --name=node.session.auth.password --value=secret_password
 ```
 
 ## Log into an iSCSI target
 
-```
-iscsiadm -m node --login
-```
-
-will log into all discovered targets. To log into a specific target:
+The following command will log into all discovered targets.
 
 ```
-iscsiadm -m node --targetname=targetname --login
+$ iscsiadm -m node --login
+```
+
+Then, to log into a specific target use:
+
+```
+$ iscsiadm -m node --targetname=targetname --login
+```
+
+The value for `targetname` is unique to your setup. For example:
+
+```
+$ iscsiadm -m node --targetname=custom_target --login
 ```
 
 ## Enable automatic iSCSI login at boot
@@ -53,8 +67,10 @@ iscsiadm -m node --targetname=targetname --login
 If you want to connect to iSCSI targets automatically at boot, run
 
 ```
-systemctl enable iscsid
+$ systemctl enable iscsid
 ```
+
+<!-- TODO: add a cloud-config or ignition example! -->
 
 ## Mounting iSCSI targets
 


### PR DESCRIPTION
Supersedes #792 

In addition to the original docs I added a short contextual sentence about iSCSI.

As noted in the original PR there are a few improvements that can be made still be made such as:

@robszumski: 

> @joshix Brainstorming some steps to polish:
> - Background
>   - add some general background on how iscsi works, just a sentence or two. It's a block device, etc.
> - Credentials section has examples for global and per-mount
>   - manual examples
>   - cloud-configs (enables iscsid)
> - Expand on the "find available targets"
>   - "You may want to manually search first, then add to a cloud-config..."
> - Mounting instructions
>   - doc has a specific iSCSI example (currently is lacking)
>   - full cloud-config
>   - possibly add a kubernetes example? ([upstream](https://github.com/kubernetes/kubernetes/blob/master/examples/iscsi/iscsi.json))

@mjg59:

> Ah yeah things get a little more complicated if you don't want to do discovery on the machine - the configuration for the target needs to be laid down in that case before login will work. We'll need to provide an example for that.

Thoughts and improvements would appreciated.  We're going to try to merge these ASAP and improve on them later just to get something out the door.
