### PR TITLE
network-config-with-networkd: change MIIMonitorSec to 1

### DIFF
--- a/os/network-config-with-networkd.md
+++ b/os/network-config-with-networkd.md
@@ -102,7 +102,7 @@ write_files:
 
       [Bond]
       Mode=0 # defaults to balance-rr
-      MIIMonitorSec=100
+      MIIMonitorSec=1
   - path: /etc/systemd/network/30-bond-dhcp.network
     permissions: 0644
     owner: root


### PR DESCRIPTION
Based on user feedback on this thread: https://groups.google.com/d/msg/coreos-user/OaOX8AuoQCE/w3qVCTqCAQAJ