### PR TITLE
Fix email in key generation script

### DIFF
--- a/quay-enterprise/generate-signing-keys.sh
+++ b/quay-enterprise/generate-signing-keys.sh
@@ -14,7 +14,7 @@ echo 'Generating public signing key'
 gpg2 --no-default-keyring --armor \
 --secret-keyring ./signing.sec --keyring ./signing.pub \
 --output $1/signing-public.gpg \
---export 
+--export $EMAIL
 
 echo 'Determining private key'
 PRIVATE_KEY=`gpg2 --no-default-keyring \

--- a/quay-enterprise/generate-signing-keys.sh
+++ b/quay-enterprise/generate-signing-keys.sh
@@ -8,11 +8,13 @@ fi
 echo 'Generating initial keys'
 gpg2 --batch --gen-key aci-signing-key-batch.txt
 
+EMAIL=`awk '{if($1=="Name-Email:") print $2}' aci-signing-key-batch.txt`
+
 echo 'Generating public signing key'
 gpg2 --no-default-keyring --armor \
 --secret-keyring ./signing.sec --keyring ./signing.pub \
 --output $1/signing-public.gpg \
---export "<support@quay.io>"
+--export 
 
 echo 'Determining private key'
 PRIVATE_KEY=`gpg2 --no-default-keyring \


### PR DESCRIPTION
The email used in generating a public signing key should be pulled from aci-signing-key-batch.txt

Changed to pull from the second entry of the row with a first entry of "Name-Email:" in aci-signing-key-batch.txt.
