### PR TITLE
os: add section on visudo usage to adding-users doc

### DIFF
--- a/os/adding-users.md
+++ b/os/adding-users.md
@@ -66,7 +66,7 @@ update-ssh-keys -u user1 user1.pem
 
 ## Grant sudo Access
 
-If you trust the user you can grant administrative privileges using visudo. visudo checks the file syntax before actually overwriting the sudoers file. This command should be ran as root to avoid losing sudo access in the event of a failure. Instead of editing /etc/sudo.conf directly you will create a new file under the `/etc/sudoers.d/` directory. When you run visudo it is required that you specify which file you are attempting to edit with the -f argument: 
+If you trust the user, you can grant administrative privileges using `visudo`. `visudo` checks the file syntax before actually overwriting the `sudoers` file. This command should be run as root to avoid losing sudo access in the event of a failure. Instead of editing `/etc/sudo.conf` directly you will create a new file under the `/etc/sudoers.d/` directory. When you run visudo, it is required that you specify which file you are attempting to edit with the `-f` argument: 
 
 ```sh
 # visudo -f /etc/sudoers.d/user1

--- a/os/adding-users.md
+++ b/os/adding-users.md
@@ -64,6 +64,33 @@ To assign an SSH key, run:
 update-ssh-keys -u user1 user1.pem
 ```
 
+## Grant sudo Access
+
+If you trust the user you can grant administrative privileges using visudo. visudo checks the file syntax before actually overwriting the sudoers file. This command should be ran as root to avoid losing sudo access in the event of a failure. Instead of editing /etc/sudo.conf directly you will create a new file under the `/etc/sudoers.d/` directory. When you run visudo it is required that you specify which file you are attempting to edit with the -f argument: 
+
+```sh
+# visudo -f /etc/sudoers.d/user1
+```
+
+Add a the line:
+
+```
+user1 ALL=(ALL) NOPASSWD: ALL
+```
+
+Check that sudo has been granted:
+
+```sh
+# su user1
+$ cat /etc/sudoers.d/user1
+cat: /etc/sudoers.d/user1: Permission denied
+
+$ sudo cat /etc/sudoers.d/user1
+user1 ALL=(ALL) NOPASSWD: ALL
+```
+
+#
+
 ## Further reading
 
 Read the [full cloud-config]({{site.baseurl}}/docs/cluster-management/setup/cloudinit-cloud-config/) guide to install users and more.


### PR DESCRIPTION
Visudo on CoreOS requires the file be specified or an error is thrown.
Issue: https://github.com/coreos/bugs/issues/1617