### PR TITLE
os/booting-on-gce: use --image-family instead of --image

### DIFF
--- a/os/booting-on-google-compute-engine.md
+++ b/os/booting-on-google-compute-engine.md
@@ -55,15 +55,15 @@ Create 3 instances from the image above using our cloud-config from `cloud-confi
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane" id="alpha-create">
       <p>The alpha channel closely tracks master and is released to frequently. The newest versions of <a href="{{site.baseurl}}/using-coreos/docker">Docker</a>, <a href="{{site.baseurl}}/using-coreos/etcd">etcd</a> and <a href="{{site.baseurl}}/using-coreos/clustering">fleet</a> will be available for testing. Current version is CoreOS {{site.alpha-channel}}.</p>
-      <pre>gcloud compute instances create core1 core2 core3 --image https://www.googleapis.com/compute/v1/{{site.data.alpha-channel.gce-image-path}} --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=cloud-config.yaml</pre>
+      <pre>gcloud compute instances create core1 core2 core3 --image-project coreos-cloud --image-family coreos-alpha --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=cloud-config.yaml</pre>
     </div>
     <div class="tab-pane" id="beta-create">
       <p>The beta channel consists of promoted alpha releases. Current version is CoreOS {{site.beta-channel}}.</p>
-      <pre>gcloud compute instances create core1 core2 core3 --image https://www.googleapis.com/compute/v1/{{site.data.beta-channel.gce-image-path}} --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=cloud-config.yaml</pre>
+      <pre>gcloud compute instances create core1 core2 core3 --image-project coreos-cloud --image-family coreos-beta --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=cloud-config.yaml</pre>
     </div>
     <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of CoreOS are battle-tested within the Beta and Alpha channels before being promoted. Current version is CoreOS {{site.stable-channel}}.</p>
-      <pre>gcloud compute instances create core1 core2 core3 --image https://www.googleapis.com/compute/v1/{{site.data.stable-channel.gce-image-path}} --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=cloud-config.yaml</pre>
+      <pre>gcloud compute instances create core1 core2 core3 --image-project coreos-cloud --image-family coreos-stable --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=cloud-config.yaml</pre>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**Commit details**
This commit removes the need to maintain exact versions or dates for
coreos in the docs example of creating gcloud compute instances.
Motivated by an out of date (or deprecated) version preventing the
docs example from running.

The GCP SDK supports image resolution via `--image-family` and
`--image-project` flags as an alternative to the `--image` flag. Using
`--image-family`, the latest non-deprecated image will be used. Rather
than `--image` where the full name must be used. Details on the flags
available at
https://cloud.google.com/sdk/gcloud/reference/compute/instances/create.

**Broken doc example**
At the time of this writing, `gcloud compute instances create` command shows:
![image](https://cloud.githubusercontent.com/assets/6200057/19630508/bf8fe856-9940-11e6-8af1-08d6b6a23a47.png)

Here the value for `--image` is `https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-1122-3-0-v20161020`.

When running the command above, you'll receive:
```
ERROR: (gcloud.compute.instances.create) Some requests did not succeed:
 - Invalid value for field 'resource.disks[0].initializeParams.sourceImage': 'https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-stable-1122-3-0-v20161020'. The referenced image resource cannot be found.
```

This is caused by the version being out of date or deprecated as seen when running ` gcloud compute images list | grep coreos`.

```
coreos-alpha-1192-2-0-v20161021                 coreos-cloud       coreos-alpha                          READY
coreos-beta-1185-2-0-v20161021                  coreos-cloud       coreos-beta                           READY
coreos-stable-1122-3-0-v20161021                coreos-cloud       coreos-stable                         READY
```

Rather than update the version, this commit focuses on resolution through `--image-family`, as detailed above.