### PR TITLE
qe: revamp section on manually adding license file

### DIFF
--- a/quay-enterprise/quay-enterprise-2.md
+++ b/quay-enterprise/quay-enterprise-2.md
@@ -20,10 +20,6 @@ Run a single instance of Quay Enterprise 2.0.0 by replacing `quay.io/coreos/regi
 
 ## Add your license to the Quay Enterprise
 
-### Quay Enterprise setup via config management
-
-Shutdown the running instance and add the `license` file downloaded above to be placed in the `conf/stack` directory, next to the existing `config.yaml`.
-
 ### Quay Enterprise setup as a container or under Kubernetes
 
 - Visit the management panel:
@@ -36,6 +32,27 @@ Sign in to a super user account and visit `http://yourregister/superuser` to vie
 - In the section entitled "License", paste in the contents of the license downloaded above
 - Click "Save Configuration Changes"
 - Restart the container (you will be prompted)
+
+### Add License without management panel
+
+Ensure QE instance has been shutdown and add the raw format license in `license` file to the directory mapped to `conf/stack`, next to the existing `config.yaml`.
+
+#### Example:
+
+`conf/stack` is mapped to `quay2/config` in `docker run` command used to bring up Quay Enterprise: 
+```
+docker run --restart=always -p 443:443 -p 80:80 --privileged=true -v /quay2/config:/conf/stack -v /quay2/storage:/datastorage -d quay.io/coreos/quay:v2.0.0
+```
+
+`license` file resides in the `quay2/config` directory:
+```
+$ ls quay2/config/
+config.yaml  license
+
+$ cat quay2/license
+eyJhbGciOiJSUzI1NiJ9.eyJzY2hlbWFWZXJzaW9uIjoidjIiLCJ2ZXJzaW9uIjoiMSIsImNyZWF0aW9uRGF0ZSI6IjIwMTYtMTAtMjZUMTc6MjM6MjJaIiwiZXhwaXJ
+[...]
+```
 
 ## Update cluster
 

--- a/quay-enterprise/quay-enterprise-2.md
+++ b/quay-enterprise/quay-enterprise-2.md
@@ -6,7 +6,7 @@ We **highly** recommend performing this upgrade during a scheduled maintainence 
 
 ## Download Quay Enterprise License
 
-To begin, download your Quay Enterprise License from [[Tectonic Accounts](https://account.tectonic.com). Please download or copy this license in **Raw Format** as a file named `license`:
+To begin, download your Quay Enterprise License from your [Tectonic Account](https://account.tectonic.com). Please download or copy this license in **Raw Format** as a file named `license`:
 
 <img src="img/raw-format.png" class="img-center" alt="Quay Enterprise License Raw Format"/>
 
@@ -33,7 +33,7 @@ Sign in to a super user account and visit `http://yourregister/superuser` to vie
 - Click "Save Configuration Changes"
 - Restart the container (you will be prompted)
 
-### Add License without management panel
+### Add license via the filesystem
 
 Ensure QE instance has been shutdown and add the raw format license in `license` file to the directory mapped to `conf/stack`, next to the existing `config.yaml`.
 


### PR DESCRIPTION
Emphasis on using the management panel over the manual option by listing it first in the doc.
Adds an example of what the config dir needs to look like before the QE container is started.