### PR TITLE
quay-enterprise/q-e-2.md: Correct version for upgrade to v2 to plain 2.0.0

### DIFF
--- a/quay-enterprise/quay-enterprise-2.md
+++ b/quay-enterprise/quay-enterprise-2.md
@@ -16,7 +16,7 @@ Shutdown all running instances of Quay Enterprise, across all clusters.
 
 ## Run a single instance of Quay Enterprise 2
 
-Run a single instance of Quay Enterprise 2.0.0 by replacing `quay.io/coreos/registry:{currentVersion}` with `quay.io/coreos/quay:v2.0.1` in your run command, startup script, config or systemd unit.
+Run a single instance of Quay Enterprise 2.0.0 by replacing `quay.io/coreos/registry:{currentVersion}` with `quay.io/coreos/quay:v2.0.0` in your run command, startup script, config or systemd unit.
 
 ## Add your license to the Quay Enterprise
 
@@ -42,7 +42,7 @@ Ensure QE instance has been shutdown and add the raw format license in `license`
 `conf/stack` is mapped to `quay2/config` in `docker run` command used to bring up Quay Enterprise:
 
 ```
-docker run --restart=always -p 443:443 -p 80:80 --privileged=true -v /quay2/config:/conf/stack -v /quay2/storage:/datastorage -d quay.io/coreos/quay:v2.0.1
+docker run --restart=always -p 443:443 -p 80:80 --privileged=true -v /quay2/config:/conf/stack -v /quay2/storage:/datastorage -d quay.io/coreos/quay:v2.0.0
 ```
 
 `license` file resides in the `quay2/config` directory:
@@ -58,7 +58,7 @@ eyJhbGciOiJSUzI1NiJ9.eyJzY2hlbWFWZXJzaW9uIjoidjIiLCJ2ZXJzaW9uIjoiMSIsImNyZWF0aW9
 
 ## Update cluster
 
-Update all remaining Quay Enterprise instances to refer to the new image (`quay.io/coreos/quay:v2.0.1`).
+Update all remaining Quay Enterprise instances to refer to the new image (`quay.io/coreos/quay:v2.0.0`).
 
 ## Verify cluster
 


### PR DESCRIPTION
In the upgrade doc, anyone running QE less than 2.0.0 must begin with 2.0.0.

(Corrects an overzealous `sed`.)