### PR TITLE
Docs: Quay Builders support with custom signed CA

### DIFF
--- a/quay-enterprise/build-support.md
+++ b/quay-enterprise/build-support.md
@@ -50,10 +50,10 @@ docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /var/run/doc
 
 When the container starts, each build worker will auto-register and start building containers once a job is triggered and it is assigned to a worker.
 
-If Quay is setup to use SSL certificate that is not globally trusted, you must mount Quay's public SSL certificates into the quay-builder container's SSL trust store. Full command looks like:
+If Quay is setup to use a SSL certificate that is not globally trusted, for example a self-signed certificate, Quay's public SSL certificates must be mounted onto the `quay-builder` container's SSL trust store. An example command to mount a certificate directory found at the host's `/path/to/ssl` looks like:
 
 ```sh
-docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /path/to/ssl:/usr/local/share/ca-certificates -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/quay-builder:v2.0.1 /bin/sh -c "/usr/sbin/update-ca-certificates ; /quay-builder"
+docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /path/to/ssl:/usr/local/share/ca-certificates -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/quay-builder:v2.1.0 /bin/sh -c "/usr/sbin/update-ca-certificates ; /quay-builder"
 ```
 
 ### Setup GitHub build (optional)

--- a/quay-enterprise/build-support.md
+++ b/quay-enterprise/build-support.md
@@ -50,6 +50,12 @@ docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /var/run/doc
 
 When the container starts, each build worker will auto-register and start building containers once a job is triggered and it is assigned to a worker.
 
+If Quay is setup to use SSL certificate that is not globally trusted, you must mount Quay's public SSL certificates into the quay-builder container's SSL trust store. Full command looks like:
+
+```sh
+docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /path/to/ssl:/usr/local/share/ca-certificates -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/quay-builder:v2.0.1 /bin/sh -c "/usr/sbin/update-ca-certificates ; /quay-builder"
+```
+
 ### Setup GitHub build (optional)
 
 If your organization plans to have builds be conducted via pushes to GitHub (or GitHub Enterprise), please continue


### PR DESCRIPTION
Add example of builders support for connecting Quay Enterprise signed by custom CA

Tested as below:
![image](https://cloud.githubusercontent.com/assets/11538902/20944414/5a9aefd2-bbd1-11e6-8536-62f81d1a5f20.png)

