### PR TITLE
dead link

### DIFF
--- a/kubernetes/network-troubleshooting.md
+++ b/kubernetes/network-troubleshooting.md
@@ -212,4 +212,4 @@ docker inspect -f '{{.State.Pid}}' [container ID]
 <!-- {% endraw %} -->
 
 [k8s-dns-check]: https://github.com/kubernetes/kubernetes/blob/release-1.2/cluster/addons/dns/README.md#how-do-i-test-if-it-is-working
-[toolbox]: ../os/install-debugging-tools.md
+[toolbox]: os/docs/latest/install-debugging-tools.md

--- a/kubernetes/network-troubleshooting.md
+++ b/kubernetes/network-troubleshooting.md
@@ -212,4 +212,4 @@ docker inspect -f '{{.State.Pid}}' [container ID]
 <!-- {% endraw %} -->
 
 [k8s-dns-check]: https://github.com/kubernetes/kubernetes/blob/release-1.2/cluster/addons/dns/README.md#how-do-i-test-if-it-is-working
-[toolbox]: os/docs/latest/install-debugging-tools.md
+[toolbox]: /os/docs/latest/install-debugging-tools.md


### PR DESCRIPTION
relative path won't work here.
currently https://coreos.com/kubernetes/docs/latest/network-troubleshooting.html redirects to 404 on https://coreos.com/os/docs/latest/docs/latest/install-debugging-tools.html
no sure if this will fix it though...