### PR TITLE
os: link to setting system-wide env vars

### DIFF
--- a/os/customizing-docker.md
+++ b/os/customizing-docker.md
@@ -299,6 +299,8 @@ systemctl daemon-reload
 systemctl restart docker
 ```
 
+Proxy environment variables can also be set [system-wide][systemd-env-vars].
+
 ### Cloud-config
 
 The easiest way to use this proxy on all of your machines is via cloud-config:
@@ -369,3 +371,4 @@ A json file `.dockercfg` can be created in your home directory that holds authen
 [mounting-storage]: mounting-storage.md
 [self-signed-certs]: generate-self-signed-certificates.md
 [systemd-socket]: https://www.freedesktop.org/software/systemd/man/systemd.socket.html
+[systemd-env-vars]: https://coreos.com/os/docs/latest/using-environment-variables-in-systemd-units.html#system-wide-environment-variables

--- a/os/update-strategies.md
+++ b/os/update-strategies.md
@@ -103,6 +103,8 @@ coreos:
       command: restart
 ```
 
+Proxy environment variables can also be set [system-wide][systemd-env-vars].
+
 ## Manually triggering an update
 
 Each machine should check in about 10 minutes after boot and roughly every hour after that. If you'd like to see it sooner, you can force an update check, which will skip any rate-limiting settings that are configured in CoreUpdate.
@@ -130,3 +132,4 @@ For more information about the supported syntax, refer to the [Locksmith documen
 
 [rollback]: manual-rollbacks.md
 [reboot-windows]: https://github.com/coreos/locksmith#reboot-windows
+[systemd-env-vars]: https://coreos.com/os/docs/latest/using-environment-variables-in-systemd-units.html#system-wide-environment-variables


### PR DESCRIPTION
We have docs for setting proxy env vars as dropins, but it would be helpful to link to how to set them system-wide