### PR TITLE
Removed ellipses to improve formatting

### DIFF
--- a/os/booting-with-pxe.md
+++ b/os/booting-with-pxe.md
@@ -178,11 +178,13 @@ usr/share/oem
 usr/share/oem/example.ign
 ```
 
-Add the `oem.cpio.gz` to your PXE boot directory and [append it][append-initrd] to the `initrd` line in your `pxelinux.cfg` and specify the path to the config:
+Add the `oem.cpio.gz` file to your PXE boot directory, then [append it][append-initrd] to the `initrd` line in your `pxelinux.cfg`. Finally, specify the URL of the config in the `kernel` line:
 
 ```
+...
 initrd coreos_production_pxe_image.cpio.gz,oem.cpio.gz
 kernel coreos_production_pxe.vmlinuz coreos.config.url=oem:///example.ign
+...
 ```
 
 ## Using CoreOS Container Linux

--- a/os/booting-with-pxe.md
+++ b/os/booting-with-pxe.md
@@ -179,11 +179,10 @@ usr/share/oem/example.ign
 ```
 
 Add the `oem.cpio.gz` to your PXE boot directory and [append it][append-initrd] to the `initrd` line in your `pxelinux.cfg` and specify the path to the config:
+
 ```
-...
 initrd coreos_production_pxe_image.cpio.gz,oem.cpio.gz
 kernel coreos_production_pxe.vmlinuz coreos.config.url=oem:///example.ign
-[etc]
 ```
 
 ## Using CoreOS Container Linux

--- a/os/booting-with-pxe.md
+++ b/os/booting-with-pxe.md
@@ -183,7 +183,7 @@ Add the `oem.cpio.gz` to your PXE boot directory and [append it][append-initrd] 
 ...
 initrd coreos_production_pxe_image.cpio.gz,oem.cpio.gz
 kernel coreos_production_pxe.vmlinuz coreos.config.url=oem:///example.ign
-...
+[etc]
 ```
 
 ## Using CoreOS Container Linux


### PR DESCRIPTION
os/booting-with-pxe.md line 186: I removed the ellipses and newline so the https://coreos.com/os/docs/latest/booting-with-pxe.html generated from this would render the initrd example textbox properly. With the ellipses (or maybe it was the newline) the kernel and initrd lines were joined together into a single line in my browser.