### PR TITLE
os/booting-on-ecs.md: systemd and contents are not valid

### DIFF
--- a/os/booting-on-ecs.md
+++ b/os/booting-on-ecs.md
@@ -11,11 +11,11 @@ When booting your [Container Linux Machines on EC2](booting-on-ec2.md), configur
 Be sure to change `ECS_CLUSTER` to the cluster name you've configured via the ECS CLI or leave it empty for the default. Here's a full config example:
 
 ```container-linux-config
-systemd:
+coreos:
  units:
    - name: amazon-ecs-agent.service
      enable: true
-     contents: |
+     content: |
        [Unit]
        Description=AWS ECS Agent
        Documentation=https://docs.aws.amazon.com/AmazonECS/latest/developerguide/


### PR DESCRIPTION
`systemd` and `contents` are not valid on CoreOS-stable-1235