### PR TITLE
os: fix clc typo in vmware example

### DIFF
--- a/os/booting-on-vmware.md
+++ b/os/booting-on-vmware.md
@@ -87,8 +87,8 @@ systemd:
 passwd:
   users:
     - name: core
-      passwordHash: $6$5s2u6/jR$un0AvWnqilcgaNB3Mkxd5yYv6mTlWfOoCYHZmfi3LDKVltj.E8XNKEcwWm...
-      sshAuthorizedKeys:
+      password_hash: $6$5s2u6/jR$un0AvWnqilcgaNB3Mkxd5yYv6mTlWfOoCYHZmfi3LDKVltj.E8XNKEcwWm...
+      ssh_authorized_keys:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGdByTgSVHq...
 ```
 


### PR DESCRIPTION
Fixes https://github.com/coreos/docs/issues/1004.