### PR TITLE
os: update users guide to use clc 

### DIFF
--- a/os/adding-users.md
+++ b/os/adding-users.md
@@ -1,25 +1,6 @@
 # Adding users
 
-You can create user accounts on a CoreOS Container Linux machine manually with `useradd` or via Ignition or cloud-config when the machine is created.
-
-## Add users via cloud-config
-
-Managing users via cloud-config is preferred because it allows you to use the same configuration across many servers and the cloud-config file can be stored in a repo and versioned. In your cloud-config, you can specify many [different parameters](https://github.com/coreos/coreos-cloudinit/blob/master/Documentation/cloud-config.md#users) for each user. Here's an example:
-
-```cloud-config
-#cloud-config
-
-users:
-  - name: elroy
-    passwd: $6$5s2u6/jR$un0AvWnqilcgaNB3Mkxd5yYv6mTlWfOoCYHZmfi3LDKVltj.E8XNKEcwWm...
-    groups:
-      - sudo
-      - docker
-    ssh-authorized-keys:
-      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGdByTgSVHq.......
-```
-
-Check out the entire [Customize with Cloud-Config](https://github.com/coreos/coreos-cloudinit/blob/master/Documentation/cloud-config.md) guide for the full details.
+You can create user accounts on a CoreOS Container Linux machine manually with `useradd` or via Ignition when the machine is created.
 
 ## Add Users via Ignition
 
@@ -88,9 +69,3 @@ cat: /etc/sudoers.d/user1: Permission denied
 $ sudo cat /etc/sudoers.d/user1
 user1 ALL=(ALL) NOPASSWD: ALL
 ```
-
-#
-
-## Further reading
-
-Read the [full cloud-config](https://github.com/coreos/coreos-cloudinit/blob/master/Documentation/cloud-config.md) guide to install users and more.

--- a/os/adding-users.md
+++ b/os/adding-users.md
@@ -6,20 +6,18 @@ You can create user accounts on a CoreOS Container Linux machine manually with `
 
 Managing users via Ignition is preferred because it allows you to use the same configuration across many servers and the Ignition config can be stored in a repo and versioned. In your Ignition config, you can specify many [different parameters](https://github.com/coreos/ignition/blob/master/doc/configuration.md) for each user. Here's an example:
 
-```json
-{
-  "ignition": { "version": "2.0.0" },
-  "passwd": {
-    "users": [{
-      "name": "elroy",
-      "passwordHash": "$6$5s2u6/jR$un0AvWnqilcgaNB3Mkxd5yYv6mTlWfOoCYHZmfi3LDKVltj.E8XNKEcwWm...",
-      "sshAuthorizedKeys": [ "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGdByTgSVHq......." ],
-      "create": {
-        "groups": ["sudo", "docker"]
-      }
-    }]
-  }
-}
+```container-linux-config
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGdByTgSVHq......."
+    - name: elroy
+      password_hash: "$6$5s2u6/jR$un0AvWnqilcgaNB3Mkxd5yYv6mTlWfOoCYHZmfi3LDKVltj.E8XNKEcwWm..."
+      ssh_authorized_keys:
+        - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGdByTgSVHq......."
+      create:
+        groups: [ sudo, docker ]
 ```
 
 ## Add user manually


### PR DESCRIPTION
Additionally, this shows how multiple users can be configured.

Fixes https://github.com/coreos/bugs/issues/1846.