### PR TITLE
os/booting-on-gce: Fix environment variable name

### DIFF
--- a/os/booting-on-google-compute-engine.md
+++ b/os/booting-on-google-compute-engine.md
@@ -32,10 +32,10 @@ systemd:
             EnvironmentFile=/run/metadata/coreos
             ExecStart=
             ExecStart=/usr/bin/etcd2 \
-                --advertise-client-urls=http://${COREOS_GCE_IPV4_LOCAL_0}:2379 \
-                --initial-advertise-peer-urls=http://${COREOS_GCE_IPV4_LOCAL_0}:2380 \
+                --advertise-client-urls=http://${COREOS_GCE_IP_LOCAL_0}:2379 \
+                --initial-advertise-peer-urls=http://${COREOS_GCE_IP_LOCAL_0}:2380 \
                 --listen-client-urls=http://0.0.0.0:2379 \
-                --listen-peer-urls=http://${COREOS_GCE_IPV4_LOCAL_0}:2380 \
+                --listen-peer-urls=http://${COREOS_GCE_IP_LOCAL_0}:2380 \
                 --discovery=https://discovery.etcd.io/<token>
 ```
 


### PR DESCRIPTION
Fix the Google Compute Engine ignition config to use the correct metadata
environment variable. COREOS_GCE_IPV4_LOCAL_0 should be
COREOS_GCE_IP_LOCAL_0.