### PR TITLE
docs/flannel/flannel-config.md: add a new section on setting ETCD_SSL_DIR variable

### DIFF
--- a/flannel/flannel-config.md
+++ b/flannel/flannel-config.md
@@ -147,6 +147,10 @@ The last step is to enable `flanneld.service` in the Ignition config:
 
 *Important*: Other units that will run in containers, including those scheduled via fleet, should include `Requires=flanneld.service`, `After=flanneld.service`, and `Restart=always|on-failure` directives. These directive are necessary because flanneld.service may fail due to etcd not being available yet. It will keep restarting and it is important for Docker based services to also keep trying until flannel is up.
 
+### Setting the environment variables
+
+If etcd requires SSL certificates, flannel will need those to communicate with etcd. This is achieved by passing the directory in which the certificates are stored to the flannel wrapper. To do so, set the environment variable, `ETCD_SSL_DIR` to `/etc/ssl` in `/etc/flannel/options.env`. 
+
 ## Under the hood
 
 To reduce the Container Linux image size, flannel daemon is stored in CoreOS Enterprise Registry as an ACI and not shipped in the Container Linux image. For those users wishing not to use flannel, it helps to keep their installation minimal. When `flanneld.service` is started, it pulls the flannel ACI from the registry.

--- a/flannel/flannel-config.md
+++ b/flannel/flannel-config.md
@@ -153,13 +153,13 @@ Flannel requires SSL certificates to communicate with a secure etcd cluster. By 
 
 For example:
 
-``` yaml
-coreos:
+``` container-linux-config
+systemd:
   units:
     - name: flanneld.service
-      drop-ins:
+      dropins:
         - name: 50-ssl.conf
-          content: |
+          contents: |
             [Service]
             Environment=ETCD_SSL_DIR=/etcd/ssl
 

--- a/flannel/flannel-config.md
+++ b/flannel/flannel-config.md
@@ -149,9 +149,7 @@ The last step is to enable `flanneld.service` in the Ignition config:
 
 ### Specifying SSL certificates
 
-Flannel requires SSL certificates to communicate with a secure etcd cluster. By default, flannel looks for these certificates in `/etc/ssl/etcd`. To use different certificates, add `Environment=ETCD_SSL_DIR` to a drop-in file for `flanneld.service`.
-
-For example:
+Flannel requires SSL certificates to communicate with a secure etcd cluster. By default, flannel looks for these certificates in `/etc/ssl/etcd`. To use different certificates, add `Environment=ETCD_SSL_DIR` to a drop-in file for `flanneld.service`. Use the following configuration snippet to achieve this:
 
 ``` container-linux-config
 systemd:
@@ -161,8 +159,7 @@ systemd:
         - name: 50-ssl.conf
           contents: |
             [Service]
-            Environment=ETCD_SSL_DIR=/etcd/ssl
-
+            Environment=ETCD_SSL_DIR=/etc/ssl
 ```
 
 ## Under the hood

--- a/flannel/flannel-config.md
+++ b/flannel/flannel-config.md
@@ -154,12 +154,12 @@ Flannel requires SSL certificates to communicate with a secure etcd cluster. By 
 For example:
 
 ``` yaml
-systemd:
+coreos:
   units:
     - name: flanneld.service
-      dropins:
+      drop-ins:
         - name: 50-ssl.conf
-          contents: |
+          content: |
             [Service]
             Environment=ETCD_SSL_DIR=/etcd/ssl
 

--- a/flannel/flannel-config.md
+++ b/flannel/flannel-config.md
@@ -147,9 +147,23 @@ The last step is to enable `flanneld.service` in the Ignition config:
 
 *Important*: Other units that will run in containers, including those scheduled via fleet, should include `Requires=flanneld.service`, `After=flanneld.service`, and `Restart=always|on-failure` directives. These directive are necessary because flanneld.service may fail due to etcd not being available yet. It will keep restarting and it is important for Docker based services to also keep trying until flannel is up.
 
-### Setting the environment variables
+### Specifying SSL certificates
 
-If etcd requires SSL certificates, flannel will need those to communicate with etcd. This is achieved by passing the directory in which the certificates are stored to the flannel wrapper. To do so, set the environment variable, `ETCD_SSL_DIR` to `/etc/ssl` in `/etc/flannel/options.env`. 
+Flannel requires SSL certificates to communicate with a secure etcd cluster. By default, flannel looks for these certificates in `/etc/ssl/etcd`. To use different certificates, add `Environment=ETCD_SSL_DIR` to a drop-in file for `flanneld.service`.
+
+For example:
+
+``` yaml
+systemd:
+  units:
+    - name: flanneld.service
+      dropins:
+        - name: 50-ssl.conf
+          contents: |
+            [Service]
+            Environment=ETCD_SSL_DIR=/etd/ssl
+
+```
 
 ## Under the hood
 

--- a/flannel/flannel-config.md
+++ b/flannel/flannel-config.md
@@ -161,7 +161,7 @@ systemd:
         - name: 50-ssl.conf
           contents: |
             [Service]
-            Environment=ETCD_SSL_DIR=/etd/ssl
+            Environment=ETCD_SSL_DIR=/etcd/ssl
 
 ```
 


### PR DESCRIPTION
Add a section on setting ETCD_SSL_DIR variable. ref: https://github.com/coreos/bugs/issues/1775#issuecomment-283243950