### PR TITLE
os/booting-on-ec2: Unbreak page and slightly improve discussion of userdata

### DIFF
--- a/os/booting-on-ec2.md
+++ b/os/booting-on-ec2.md
@@ -262,6 +262,11 @@ First we need to create a security group to allow Container Linux instances to c
           Next, we need to specify a discovery URL, which contains a unique token that allows us to find other hosts in our cluster. If you're launching your first machine, generate one at <a href="https://discovery.etcd.io/new?size=3">https://discovery.etcd.io/new?size=3</a>, configure the `?size=` to your initial cluster size and add it to the metadata. You should re-use this key for each machine in the cluster.
         </li>
         <li>
+          Back in the EC2 dashboard, paste this Ignition configuration into the "User Data" field.
+          <ul>
+            <li>Paste configuration into "User Data"</li>
+            <li>"Continue"</li>
+          </ul>
 ```container-linux-config
 systemd:
   units:
@@ -288,11 +293,6 @@ systemd:
     - name: fleet.service
       enable: true
 ```
-          Back in the EC2 dashboard, paste this information verbatim into the "User Data" field.
-          <ul>
-            <li>Paste link into "User Data"</li>
-            <li>"Continue"</li>
-          </ul>
         </li>
         <li>
           Storage Configuration
@@ -346,6 +346,11 @@ systemd:
           Next, we need to specify a discovery URL, which contains a unique token that allows us to find other hosts in our cluster. If you're launching your first machine, generate one at <a href="https://discovery.etcd.io/new?size=3">https://discovery.etcd.io/new?size=3</a>, configure the `?size=` to your initial cluster size and add it to the metadata. You should re-use this key for each machine in the cluster.
         </li>
         <li>
+          Back in the EC2 dashboard, paste this Ignition configuration into the "User Data" field.
+          <ul>
+            <li>Paste configuration into "User Data"</li>
+            <li>"Continue"</li>
+          </ul>
 ```container-linux-config
 systemd:
   units:
@@ -372,11 +377,6 @@ systemd:
     - name: fleet.service
       enable: true
 ```
-          Back in the EC2 dashboard, paste this information verbatim into the "User Data" field.
-          <ul>
-            <li>Paste link into "User Data"</li>
-            <li>"Continue"</li>
-          </ul>
         </li>
         <li>
           Storage Configuration
@@ -430,6 +430,11 @@ systemd:
           Next, we need to specify a discovery URL, which contains a unique token that allows us to find other hosts in our cluster. If you're launching your first machine, generate one at <a href="https://discovery.etcd.io/new?size=3">https://discovery.etcd.io/new?size=3</a>, configure the `?size=` to your initial cluster size and add it to the metadata. You should re-use this key for each machine in the cluster.
         </li>
         <li>
+          Back in the EC2 dashboard, paste this Ignition configuration into the "User Data" field.
+          <ul>
+            <li>Paste configuration into "User Data"</li>
+            <li>"Continue"</li>
+          </ul>
 ```container-linux-config
 systemd:
   units:
@@ -456,11 +461,6 @@ systemd:
     - name: fleet.service
       enable: true
 ```
-          Back in the EC2 dashboard, paste this information verbatim into the "User Data" field.
-          <ul>
-            <li>Paste link into "User Data"</li>
-            <li>"Continue"</li>
-          </ul>
         </li>
         <li>
           Storage Configuration

--- a/os/booting-on-ec2.md
+++ b/os/booting-on-ec2.md
@@ -262,32 +262,32 @@ First we need to create a security group to allow Container Linux instances to c
           Next, we need to specify a discovery URL, which contains a unique token that allows us to find other hosts in our cluster. If you're launching your first machine, generate one at <a href="https://discovery.etcd.io/new?size=3">https://discovery.etcd.io/new?size=3</a>, configure the `?size=` to your initial cluster size and add it to the metadata. You should re-use this key for each machine in the cluster.
         </li>
         <li>
-          ```container-linux-config
-          systemd:
-            units:
-              - name: etcd2.service
-                enable: true
-                dropins:
-                  - name: cluster.conf
-                    # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
-                    # specify the initial size of your cluster with ?size=X
-                    contents: |
-                      [Unit]
-                      Requires=coreos-metadata.service
-                      After=coreos-metadata.service
+```container-linux-config
+systemd:
+  units:
+    - name: etcd2.service
+      enable: true
+      dropins:
+        - name: cluster.conf
+          # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
+          # specify the initial size of your cluster with ?size=X
+          contents: |
+            [Unit]
+            Requires=coreos-metadata.service
+            After=coreos-metadata.service
 
-                      [Service]
-                      EnvironmentFile=/run/metadata/coreos
-                      ExecStart=
-                      ExecStart=/usr/bin/etcd2 \
-                          --advertise-client-urls=http://${COREOS_EC2_IPV4_PUBLIC}:2379 \
-                          --initial-advertise-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
-                          --listen-client-urls=http://0.0.0.0:2379 \
-                          --listen-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
-                          --discovery=https://discovery.etcd.io/<token>
-              - name: fleet.service
-                enable: true
-          ```
+            [Service]
+            EnvironmentFile=/run/metadata/coreos
+            ExecStart=
+            ExecStart=/usr/bin/etcd2 \
+                --advertise-client-urls=http://${COREOS_EC2_IPV4_PUBLIC}:2379 \
+                --initial-advertise-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
+                --listen-client-urls=http://0.0.0.0:2379 \
+                --listen-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
+                --discovery=https://discovery.etcd.io/<token>
+    - name: fleet.service
+      enable: true
+```
           Back in the EC2 dashboard, paste this information verbatim into the "User Data" field.
           <ul>
             <li>Paste link into "User Data"</li>
@@ -346,32 +346,32 @@ First we need to create a security group to allow Container Linux instances to c
           Next, we need to specify a discovery URL, which contains a unique token that allows us to find other hosts in our cluster. If you're launching your first machine, generate one at <a href="https://discovery.etcd.io/new?size=3">https://discovery.etcd.io/new?size=3</a>, configure the `?size=` to your initial cluster size and add it to the metadata. You should re-use this key for each machine in the cluster.
         </li>
         <li>
-          ```container-linux-config
-          systemd:
-            units:
-              - name: etcd2.service
-                enable: true
-                dropins:
-                  - name: cluster.conf
-                    # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
-                    # specify the initial size of your cluster with ?size=X
-                    contents: |
-                      [Unit]
-                      Requires=coreos-metadata.service
-                      After=coreos-metadata.service
+```container-linux-config
+systemd:
+  units:
+    - name: etcd2.service
+      enable: true
+      dropins:
+        - name: cluster.conf
+          # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
+          # specify the initial size of your cluster with ?size=X
+          contents: |
+            [Unit]
+            Requires=coreos-metadata.service
+            After=coreos-metadata.service
 
-                      [Service]
-                      EnvironmentFile=/run/metadata/coreos
-                      ExecStart=
-                      ExecStart=/usr/bin/etcd2 \
-                          --advertise-client-urls=http://${COREOS_EC2_IPV4_PUBLIC}:2379 \
-                          --initial-advertise-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
-                          --listen-client-urls=http://0.0.0.0:2379 \
-                          --listen-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
-                          --discovery=https://discovery.etcd.io/<token>
-              - name: fleet.service
-                enable: true
-          ```
+            [Service]
+            EnvironmentFile=/run/metadata/coreos
+            ExecStart=
+            ExecStart=/usr/bin/etcd2 \
+                --advertise-client-urls=http://${COREOS_EC2_IPV4_PUBLIC}:2379 \
+                --initial-advertise-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
+                --listen-client-urls=http://0.0.0.0:2379 \
+                --listen-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
+                --discovery=https://discovery.etcd.io/<token>
+    - name: fleet.service
+      enable: true
+```
           Back in the EC2 dashboard, paste this information verbatim into the "User Data" field.
           <ul>
             <li>Paste link into "User Data"</li>
@@ -430,32 +430,32 @@ First we need to create a security group to allow Container Linux instances to c
           Next, we need to specify a discovery URL, which contains a unique token that allows us to find other hosts in our cluster. If you're launching your first machine, generate one at <a href="https://discovery.etcd.io/new?size=3">https://discovery.etcd.io/new?size=3</a>, configure the `?size=` to your initial cluster size and add it to the metadata. You should re-use this key for each machine in the cluster.
         </li>
         <li>
-          ```container-linux-config
-          systemd:
-            units:
-              - name: etcd2.service
-                enable: true
-                dropins:
-                  - name: cluster.conf
-                    # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
-                    # specify the initial size of your cluster with ?size=X
-                    contents: |
-                      [Unit]
-                      Requires=coreos-metadata.service
-                      After=coreos-metadata.service
+```container-linux-config
+systemd:
+  units:
+    - name: etcd2.service
+      enable: true
+      dropins:
+        - name: cluster.conf
+          # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
+          # specify the initial size of your cluster with ?size=X
+          contents: |
+            [Unit]
+            Requires=coreos-metadata.service
+            After=coreos-metadata.service
 
-                      [Service]
-                      EnvironmentFile=/run/metadata/coreos
-                      ExecStart=
-                      ExecStart=/usr/bin/etcd2 \
-                          --advertise-client-urls=http://${COREOS_EC2_IPV4_PUBLIC}:2379 \
-                          --initial-advertise-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
-                          --listen-client-urls=http://0.0.0.0:2379 \
-                          --listen-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
-                          --discovery=https://discovery.etcd.io/<token>
-              - name: fleet.service
-                enable: true
-          ```
+            [Service]
+            EnvironmentFile=/run/metadata/coreos
+            ExecStart=
+            ExecStart=/usr/bin/etcd2 \
+                --advertise-client-urls=http://${COREOS_EC2_IPV4_PUBLIC}:2379 \
+                --initial-advertise-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
+                --listen-client-urls=http://0.0.0.0:2379 \
+                --listen-peer-urls=http://${COREOS_EC2_IPV4_LOCAL}:2380 \
+                --discovery=https://discovery.etcd.io/<token>
+    - name: fleet.service
+      enable: true
+```
           Back in the EC2 dashboard, paste this information verbatim into the "User Data" field.
           <ul>
             <li>Paste link into "User Data"</li>


### PR DESCRIPTION
CommonMark doesn't allow code fences to be indented more than three spaces. This was breaking everything on the page starting from "Launching a test cluster". Also improve wording slightly and introduce the CL config before showing it.