### PR TITLE
os/kernel-modules: fix mounting of overlay

### DIFF
--- a/os/kernel-modules.md
+++ b/os/kernel-modules.md
@@ -12,7 +12,7 @@ sudo mount \
     -t overlay overlay /lib/modules
 ```
 
-The following systemd unit can be written to `/etc/systemd/system/local-fs.target.wants/lib-modules.mount` so this overlay is mounted automatically on boot.
+The following systemd unit can be written to `/etc/systemd/system/lib-modules.mount`.
 
 ```ini
 [Unit]
@@ -28,6 +28,12 @@ Options=lowerdir=/lib/modules,upperdir=/opt/modules,workdir=/opt/modules.wd
 
 [Install]
 WantedBy=local-fs.target
+```
+
+Enable the unit so this overlay is mounted automatically on boot.
+
+```sh
+sudo systemctl enable lib-modules.mount
 ```
 
 ## Prepare a CoreOS Container Linux development container


### PR DESCRIPTION
I noticed that as of 1353.4.0 (maybe earlier) the lib-modules.mount
unit was no longer started on boot. Checking `systemctl status
local-fs.target` returned:

```
local-fs.target: Wants dependency dropin
/etc/systemd/system/local-fs.target.wants/lib-modules.mount is not a
symlink, ignoring.
```

To fix this, we can create the file in /etc/systemd/system and then
enable it to create the symlink. I tested this on my machines and found
it to work.