### PR TITLE
os: remove extra clcs

### DIFF
--- a/os/booting-on-ec2.md
+++ b/os/booting-on-ec2.md
@@ -278,22 +278,6 @@ First we need to create a security group to allow Container Linux instances to c
             <li>Paste configuration into "User Data"</li>
             <li>"Continue"</li>
           </ul>
-```container-linux-config:ec2
-etcd:
-  # All options get passed as command line flags to etcd.
-  # Any information inside curly braces comes from the machine at boot time.
-
-  # multi_region and multi_cloud deployments need to use {PUBLIC_IPV4}
-  advertise_client_urls:       "http://{PRIVATE_IPV4}:2379"
-  initial_advertise_peer_urls: "http://{PRIVATE_IPV4}:2380"
-  # listen on both the official ports and the legacy ports
-  # legacy ports can be omitted if your application doesn't depend on them
-  listen_client_urls:          "http://0.0.0.0:2379"
-  listen_peer_urls:            "http://{PRIVATE_IPV4}:2380"
-  # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
-  # specify the initial size of your cluster with ?size=X
-  discovery:                   "https://discovery.etcd.io/<token>"
-```
         </li>
         <li>
           Storage Configuration
@@ -368,22 +352,6 @@ etcd:
             <li>Paste configuration into "User Data"</li>
             <li>"Continue"</li>
           </ul>
-```container-linux-config:ec2
-etcd:
-  # All options get passed as command line flags to etcd.
-  # Any information inside curly braces comes from the machine at boot time.
-
-  # multi_region and multi_cloud deployments need to use {PUBLIC_IPV4}
-  advertise_client_urls:       "http://{PRIVATE_IPV4}:2379"
-  initial_advertise_peer_urls: "http://{PRIVATE_IPV4}:2380"
-  # listen on both the official ports and the legacy ports
-  # legacy ports can be omitted if your application doesn't depend on them
-  listen_client_urls:          "http://0.0.0.0:2379"
-  listen_peer_urls:            "http://{PRIVATE_IPV4}:2380"
-  # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
-  # specify the initial size of your cluster with ?size=X
-  discovery:                   "https://discovery.etcd.io/<token>"
-```
         </li>
         <li>
           Storage Configuration
@@ -458,22 +426,6 @@ etcd:
             <li>Paste configuration into "User Data"</li>
             <li>"Continue"</li>
           </ul>
-```container-linux-config:ec2
-etcd:
-  # All options get passed as command line flags to etcd.
-  # Any information inside curly braces comes from the machine at boot time.
-
-  # multi_region and multi_cloud deployments need to use {PUBLIC_IPV4}
-  advertise_client_urls:       "http://{PRIVATE_IPV4}:2379"
-  initial_advertise_peer_urls: "http://{PRIVATE_IPV4}:2380"
-  # listen on both the official ports and the legacy ports
-  # legacy ports can be omitted if your application doesn't depend on them
-  listen_client_urls:          "http://0.0.0.0:2379"
-  listen_peer_urls:            "http://{PRIVATE_IPV4}:2380"
-  # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
-  # specify the initial size of your cluster with ?size=X
-  discovery:                   "https://discovery.etcd.io/<token>"
-```
         </li>
         <li>
           Storage Configuration


### PR DESCRIPTION
This looks like it was leftover from testing how markdown handled
indented code blocks.