### PR TITLE
*: change links from ct's getting started page to os/provisioning.md

### DIFF
--- a/coreupdate/configure-machines.md
+++ b/coreupdate/configure-machines.md
@@ -12,7 +12,7 @@ In addition to the default groups, you may choose to create your own group that 
 
 To place a Container Linux machine in one of these groups, you must configure the update settings via a Container Linux Config or a file on disk.
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: ../os/provisioning.md
 
 ### Join preconfigured group
 

--- a/etcd/etcd-live-cluster-reconfiguration.md
+++ b/etcd/etcd-live-cluster-reconfiguration.md
@@ -224,7 +224,7 @@ The next steps are those described in the [Change etcd cluster size][change-clus
 
 
 [change-cluster-size]: #change-etcd-cluster-size
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: ../os/provisioning.md
 [data-dir]: https://github.com/coreos/etcd/blob/master/Documentation/op-guide/configuration.md#-data-dir
 [disaster-recovery]: https://github.com/coreos/etcd/blob/master/Documentation/op-guide/recovery.md#disaster-recovery
 [drop-in]: ../os/using-systemd-drop-in-units.md

--- a/etcd/getting-started-with-etcd.md
+++ b/etcd/getting-started-with-etcd.md
@@ -225,4 +225,4 @@ $ curl http://127.0.0.1:2379/v2/keys/foo
 
 
 [etcd-v3-upgrade]: https://github.com/coreos/etcd/blob/master/Documentation/upgrades/upgrade_3_0.md
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: ../os/provisioning.md

--- a/fleet/launching-containers-fleet.md
+++ b/fleet/launching-containers-fleet.md
@@ -241,7 +241,7 @@ Global units can deployed to a subset of matching machines with the `MachineMeta
 
 Applications with complex and specific requirements can target a subset of the cluster for scheduling via machine metadata. Powerful deployment topologies can be achieved &mdash; schedule units based on the machine's region, rack location, disk speed or anything else you can think of.
 
-Metadata can be provided via [a Container Linux Config](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md) or a [config file](https://github.com/coreos/fleet/blob/master/Documentation/deployment-and-configuration.md). Here's an example config file:
+Metadata can be provided via [a Container Linux Config](../os/provisioning.md) or a [config file](https://github.com/coreos/fleet/blob/master/Documentation/deployment-and-configuration.md). Here's an example config file:
 
 ```ini
 # Comma-delimited key/value pairs that are published to the fleet registry.

--- a/os/booting-on-azure.md
+++ b/os/booting-on-azure.md
@@ -110,4 +110,4 @@ Now that you have a machine booted it is time to play around. Check out the [Con
 [ssh]: http://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-use-ssh-key/
 [update-docs]: https://coreos.com/why/#updates
 [xplat-cli]: http://azure.microsoft.com/en-us/documentation/articles/xplat-cli/
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md

--- a/os/booting-on-digitalocean.md
+++ b/os/booting-on-digitalocean.md
@@ -95,7 +95,7 @@ etcd:
   discovery:                   "https://discovery.etcd.io/<token>"
 ```
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 
 ### Adding more machines
 

--- a/os/booting-on-ec2.md
+++ b/os/booting-on-ec2.md
@@ -140,7 +140,7 @@ etcd:
 ```
 
 [ec2-user-data]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 
 ### Instance storage
 
@@ -257,7 +257,7 @@ First we need to create a security group to allow Container Linux instances to c
           Next, we need to specify a discovery URL, which contains a unique token that allows us to find other hosts in our cluster. If you're launching your first machine, generate one at <a href="https://discovery.etcd.io/new?size=3">https://discovery.etcd.io/new?size=3</a>, configure the `?size=` to your initial cluster size and add it to the metadata. You should re-use this key for each machine in the cluster.
         </li>
         <li>
-          Use <a href="https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
+          Use <a href="provisioning.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
           ```container-linux-config:ec2
           etcd:
             # All options get passed as command line flags to etcd.
@@ -331,7 +331,7 @@ First we need to create a security group to allow Container Linux instances to c
           Next, we need to specify a discovery URL, which contains a unique token that allows us to find other hosts in our cluster. If you're launching your first machine, generate one at <a href="https://discovery.etcd.io/new?size=3">https://discovery.etcd.io/new?size=3</a>, configure the `?size=` to your initial cluster size and add it to the metadata. You should re-use this key for each machine in the cluster.
         </li>
         <li>
-          Use <a href="https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
+          Use <a href="provisioning.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
           ```container-linux-config:ec2
           etcd:
             # All options get passed as command line flags to etcd.
@@ -405,7 +405,7 @@ First we need to create a security group to allow Container Linux instances to c
           Next, we need to specify a discovery URL, which contains a unique token that allows us to find other hosts in our cluster. If you're launching your first machine, generate one at <a href="https://discovery.etcd.io/new?size=3">https://discovery.etcd.io/new?size=3</a>, configure the `?size=` to your initial cluster size and add it to the metadata. You should re-use this key for each machine in the cluster.
         </li>
         <li>
-          Use <a href="https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
+          Use <a href="provisioning.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
           ```container-linux-config:ec2
           etcd:
             # All options get passed as command line flags to etcd.

--- a/os/booting-on-ecs.md
+++ b/os/booting-on-ecs.md
@@ -58,7 +58,7 @@ The example above pulls the latest official Amazon ECS agent container from the 
 
 If you want to configure SSH keys in order to log in, mount disks or configure other options, see the [Container Linux Configs documentation][cl-configs].
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 [ignition-docs]: https://coreos.com/ignition/docs/latest
 
 ## Connect ECS to an existing cluster

--- a/os/booting-on-google-compute-engine.md
+++ b/os/booting-on-google-compute-engine.md
@@ -33,7 +33,7 @@ etcd:
   discovery:                   "https://discovery.etcd.io/<token>"
 ```
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 
 ## Choosing a channel
 

--- a/os/booting-on-openstack.md
+++ b/os/booting-on-openstack.md
@@ -183,4 +183,4 @@ If you would like to create multiple clusters you'll need to generate and use a 
 
 Now that you have instances booted it is time to play around. Check out the [Container Linux Quickstart](quickstart.md) guide or dig into [more specific topics](https://coreos.com/docs).
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md

--- a/os/booting-on-packet.md
+++ b/os/booting-on-packet.md
@@ -56,7 +56,7 @@ etcd:
   discovery:                   "https://discovery.etcd.io/<token>"
 ```
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 
 ## Using CoreOS Container Linux
 

--- a/os/booting-on-vmware.md
+++ b/os/booting-on-vmware.md
@@ -93,7 +93,7 @@ etcd:
   discovery:                   "https://discovery.etcd.io/<token>"
 ```
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 
 ## VMware Guestinfo interface
 

--- a/os/booting-with-ipxe.md
+++ b/os/booting-with-ipxe.md
@@ -120,5 +120,5 @@ Similar to the [OEM partition][oem] in Container Linux disk images, iPXE images 
 
 Now that you have a machine booted it is time to play around. Check out the [Container Linux Quickstart](quickstart.md) guide or dig into [more specific topics](https://coreos.com/docs).
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 [ignition]: https://coreos.com/ignition/docs/latest

--- a/os/booting-with-pxe.md
+++ b/os/booting-with-pxe.md
@@ -224,7 +224,7 @@ Now that you have a machine booted it is time to play around. Check out the [Con
 [docs]: https://coreos.com/docs
 [ignition]: https://coreos.com/ignition/docs/latest
 [install-to-disk]: installing-to-disk.md
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 [irc]: irc://irc.freenode.org:6667/#coreos
 [oem]: notes-for-distributors.md#image-customization
 [qs]: quickstart.md

--- a/os/booting-with-qemu.md
+++ b/os/booting-with-qemu.md
@@ -172,7 +172,7 @@ Container Linux allows you to configure machine parameters, configure networking
 
 This will pass the contents of `config.ign` through to Ignition, which runs in the virtual machine.
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 
 ## Using CoreOS Container Linux
 

--- a/os/cluster-discovery.md
+++ b/os/cluster-discovery.md
@@ -11,7 +11,7 @@ $ curl -w "\n" 'https://discovery.etcd.io/new?size=3'
 https://discovery.etcd.io/6a28e078895c5ec737174db2419bb2f3
 ```
 
-The discovery URL can be provided to each Container Linux machine via [Container Linux Configs](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md). The rest of this guide will explain what's happening behind the scenes, but if you're trying to get clustered as quickly as possible, all you need to do is provide a _fresh, unique_ discovery token in your config.
+The discovery URL can be provided to each Container Linux machine via [Container Linux Configs](provisioning.md). The rest of this guide will explain what's happening behind the scenes, but if you're trying to get clustered as quickly as possible, all you need to do is provide a _fresh, unique_ discovery token in your config.
 
 Boot each one of the machines with identical Container Linux Config and they should be automatically clustered:
 

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -216,4 +216,4 @@ storage:
 [systemd-timesyncd]: http://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html
 [systemd.network]: http://www.freedesktop.org/software/systemd/man/systemd.network.html
 [timesyncd.conf]: http://www.freedesktop.org/software/systemd/man/timesyncd.conf.html
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md

--- a/os/configuring-dns.md
+++ b/os/configuring-dns.md
@@ -43,4 +43,4 @@ Only nss-aware applications can take advantage of the `systemd-resolved` cache. 
 [systemd-networkd]: http://www.freedesktop.org/software/systemd/man/systemd-networkd.service.html
 [resolved.conf]: http://www.freedesktop.org/software/systemd/man/resolved.conf.html
 [nsswitch.conf]: http://man7.org/linux/man-pages/man5/nsswitch.conf.5.html
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md

--- a/os/customizing-docker.md
+++ b/os/customizing-docker.md
@@ -344,4 +344,4 @@ A json file `.dockercfg` can be created in your home directory that holds authen
 [self-signed-certs]: generate-self-signed-certificates.md
 [systemd-socket]: https://www.freedesktop.org/software/systemd/man/systemd.socket.html
 [systemd-env-vars]: https://coreos.com/os/docs/latest/using-environment-variables-in-systemd-units.html#system-wide-environment-variables
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md

--- a/os/customizing-sshd.md
+++ b/os/customizing-sshd.md
@@ -4,7 +4,7 @@ Container Linux defaults to running an OpenSSH daemon using `systemd` socket act
 
 As a practical example, when a client fails to connect by not completing the TCP connection (e.g. because the "client" is actually a TCP port scanner), the MOTD may report failures of `systemd` units (which will be named by the source IP that failed to connect) next time you log in to the Container Linux host. These failures are not themselves harmful, but it is a good general practice to change how SSH listens, either by changing the IP address `sshd` listens to from the default setting (which listens on all configured interfaces), changing the default port, or both.
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 
 ## Customizing sshd with a Container Linux Config
 

--- a/os/installing-to-disk.md
+++ b/os/installing-to-disk.md
@@ -133,5 +133,5 @@ Now that you have a machine booted it is time to play around. Check out the [Con
 [coreos-iso]: booting-with-iso.md
 [clc-section]: #container-linux-configs
 [coreos-install]: https://raw.github.com/coreos/init/master/bin/coreos-install
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 [ct-docs]: https://github.com/coreos/container-linux-config-transpiler/tree/master/doc

--- a/os/iscsi.md
+++ b/os/iscsi.md
@@ -126,4 +126,4 @@ See the [mounting storage docs][mounting-storage] for an example.
 
 [iscsi-wiki]: https://en.wikipedia.org/wiki/ISCSI
 [mounting-storage]: mounting-storage.md
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md

--- a/os/network-config-with-networkd.md
+++ b/os/network-config-with-networkd.md
@@ -186,7 +186,7 @@ systemd:
             Environment=SYSTEMD_LOG_LEVEL=debug
 ```
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 
 ## Further reading
 

--- a/os/power-management.md
+++ b/os/power-management.md
@@ -44,4 +44,4 @@ systemd:
 
 More information on further tuning each governor is available in the [Kernel Documentation](https://www.kernel.org/doc/Documentation/cpu-freq/governors.txt)
 
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md

--- a/os/quickstart.md
+++ b/os/quickstart.md
@@ -192,4 +192,4 @@ Fleet has many more features that you can explore in the guides below.
 [iso-docs]: booting-with-iso.md
 [install-docs]: installing-to-disk.md
 [ignition]: https://coreos.com/blog/introducing-ignition.html
-[cl-configs]:https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md

--- a/os/reading-the-system-log.md
+++ b/os/reading-the-system-log.md
@@ -119,7 +119,7 @@ systemd:
 ```
 
 [drop-ins]: using-systemd-drop-in-units.md
-[ct-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[ct-configs]: provisioning.md
 
 ## More information
 

--- a/os/registry-authentication.md
+++ b/os/registry-authentication.md
@@ -232,5 +232,5 @@ For details, check out the [Container Linux Config examples][ct-examples].
 [quay-site]: https://quay.io/
 [rfc-2397]: https://tools.ietf.org/html/rfc2397
 [rkt-config]: https://coreos.com/rkt/docs/latest/configuration.html#configuration-kinds
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 [ct-examples]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/examples.md

--- a/os/using-environment-variables-in-systemd-units.md
+++ b/os/using-environment-variables-in-systemd-units.md
@@ -121,7 +121,7 @@ For more systemd examples, check out these documents:
 [customizing-sshd]: customizing-sshd.md#changing-the-sshd-port
 [customizing-etcd]: customize-etcd-unit.md
 [customizing-docker]: customizing-docker.md#using-a-dockercfg-file-for-authentication
-[cl-configs]: https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md
+[cl-configs]: provisioning.md
 [etcd-discovery]: cluster-discovery.md
 [systemd-udev]: using-systemd-and-udev-rules.md
 [etcd-cluster-reconfiguration]: ../etcd/etcd-live-cluster-reconfiguration.md

--- a/quay-enterprise/configure-machines.md
+++ b/quay-enterprise/configure-machines.md
@@ -8,7 +8,7 @@ This guide we will assume you have the DNS record `registry.example.com` configu
 
 Each Container Linux machine needs to be configured with the username and password for a robot account in order to deploy your containers. Docker looks for configured credentials in a `.dockercfg` file located within the user's home directory. You can download this file directly from the Quay Enterprise interface. Let's assume you've created a robot account called `myapp+deployment`.
 
-Writing the `.dockercfg` can be specified in [a Container Linux Config](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/getting-started.md) with the files parameter, or created manually on each machine.
+Writing the `.dockercfg` can be specified in [a Container Linux Config](../os/provisioning.md) with the files parameter, or created manually on each machine.
 
 ### Kubernetes pull secret
 


### PR DESCRIPTION
The new provisioning document is a better landing page for readers who
wish to know more about Container Linux Configs than the getting started
document for ct, so this commit changes all links to the latter to point
to the former.