### PR TITLE
quay: update v2.2.0 -> v2.3.0 image tags

### DIFF
--- a/quay-enterprise/build-support.md
+++ b/quay-enterprise/build-support.md
@@ -28,7 +28,7 @@ One or more build workers will communicate with Quay Enterprise to build new con
 Pull down the latest copy of the image. **Make sure to pull the version tagged matching your Quay Enterprise version**.
 
 ```sh
-docker pull quay.io/coreos/quay-builder:v2.2.0
+docker pull quay.io/coreos/quay-builder:v2.3.0
 ```
 
 ### Run the build worker image
@@ -45,7 +45,7 @@ Use the environment variable `SERVER` to tell the worker the hostname at which Q
 Here's what the full command looks like:
 
 ```sh
-docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/quay-builder:v2.2.0
+docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/quay-builder:v2.3.0
 ```
 
 When the container starts, each build worker will auto-register and start building containers once a job is triggered and it is assigned to a worker.
@@ -53,7 +53,7 @@ When the container starts, each build worker will auto-register and start buildi
 If Quay is setup to use a SSL certificate that is not globally trusted, for example a self-signed certificate, Quay's public SSL certificates must be mounted onto the `quay-builder` container's SSL trust store. An example command to mount a certificate directory found at the host's `/path/to/ssl` looks like:
 
 ```sh
-docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /path/to/ssl:/usr/local/share/ca-certificates -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/quay-builder:v2.2.0 /bin/sh -c "/usr/sbin/update-ca-certificates ; /quay-builder"
+docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /path/to/ssl:/usr/local/share/ca-certificates -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/quay-builder:v2.3.0 /bin/sh -c "/usr/sbin/update-ca-certificates ; /quay-builder"
 ```
 
 ### Setup GitHub build (optional)

--- a/quay-enterprise/initial-setup.md
+++ b/quay-enterprise/initial-setup.md
@@ -46,7 +46,7 @@ The `config.json` file will look like this:
 }
 ```
 
-`config.json` contains your credentials for the `quay.io/coreos/quay` repository. Save this file to your Container Linux machine in `/home/core/.docker/config.json` and `/root/.docker/config.json`. You should now be able to execute `docker pull quay.io/coreos/quay:v2.2.0` to download the container.
+`config.json` contains your credentials for the `quay.io/coreos/quay` repository. Save this file to your Container Linux machine in `/home/core/.docker/config.json` and `/root/.docker/config.json`. You should now be able to execute `docker pull quay.io/coreos/quay:v2.3.0` to download the container.
 
 ## Setting up the directories
 
@@ -62,7 +62,7 @@ mkdir config
 Run the following command, replacing `/local/path/to/the/config/directory` and `/local/path/to/the/storage/directory` with the absolute paths to the directories created above:
 
 ```
-sudo docker run --restart=always -p 443:443 -p 80:80 --privileged=true -v /local/path/to/the/config/directory:/conf/stack -v /local/path/to/the/storage/directory:/datastorage -d quay.io/coreos/quay:v2.2.0
+sudo docker run --restart=always -p 443:443 -p 80:80 --privileged=true -v /local/path/to/the/config/directory:/conf/stack -v /local/path/to/the/storage/directory:/datastorage -d quay.io/coreos/quay:v2.3.0
 ```
 
 <img src="img/db-setup-full.png" class="img-center" alt="Quay Enterprise Setup Screen"/>

--- a/quay-enterprise/insert-custom-cert.md
+++ b/quay-enterprise/insert-custom-cert.md
@@ -34,7 +34,7 @@ Obtain the quay container's `CONTAINER ID` with `docker ps`:
 ```
 $ docker ps
 CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS              PORTS
-5a3e82c4a75f        quay.io/coreos/quay:v2.2.0           "/sbin/my_init"          24 hours ago        Up 18 hours         0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp, 8443/tcp   grave_keller
+5a3e82c4a75f        quay.io/coreos/quay:v2.3.0           "/sbin/my_init"          24 hours ago        Up 18 hours         0.0.0.0:80->80/tcp, 0.0.0.0:443->443/tcp, 8443/tcp   grave_keller
 ```
 
 Restart the container with that ID:

--- a/quay-enterprise/tectonic/files/quay-enterprise-app-rc.yml
+++ b/quay-enterprise/tectonic/files/quay-enterprise-app-rc.yml
@@ -22,7 +22,7 @@ spec:
             secretName: quay-enterprise-config-secret
       containers:
       - name: quay-enterprise-app
-        image: quay.io/coreos/quay:v2.2.0
+        image: quay.io/coreos/quay:v2.3.0
         ports:
         - containerPort: 80
         volumeMounts:


### PR DESCRIPTION
Quay just got an update.
This updates the image tags appropriately.