### PR TITLE
coreupdate: add section on syncing packages to on-premises-deployment.md

### DIFF
--- a/coreupdate/on-premises-deployment.md
+++ b/coreupdate/on-premises-deployment.md
@@ -100,7 +100,7 @@ DBMAXACTIVE: 100
 # (Optional) Enable if syncing with upstream CoreUpdate instances.
 # Zero value is disabled.
 # This should be disabled if you plan to synchronize packages manually.
-UPSTREAM_SYNC_INTERVAL: 0
+UPSTREAM_SYNC_INTERVAL: 1
 
 # (Optional) enables TLS
 #TLS_CERT_FILE:
@@ -194,6 +194,27 @@ To sync the "CoreOS" application it must exist and have the same application id 
 
 ```bash
 updateservicectl --server=http://localhost:8000 --user=admin --key=<previously-generated-key> app create --label=CoreOS --app-id=e96281a6-d1af-4bde-9a0a-97b76e56dc57
+```
+
+This step needs to be repeated for the CoreOS ARM application:
+
+```bash
+updateservicectl --server=http://localhost:8000 --user=admin --key=<previously-generated-key> app create --label=CoreOS-ARM --app-id=103867da-e3a2-4c92-b0b3-7fbd7f7d8b71
+```
+
+#### Sync public upstream 
+
+Create a `Public CoreOS` upstream:
+
+```bash
+updateservicectl upstream create --label="Public CoreOS" \
+--url="https://public.update.core-os.net"
+```
+
+Perform initial upstream sync: 
+
+```bash
+updateservicectl upstream sync
 ```
 
 You can now point your browser to `http://localhost:8000` to view the control panel.

--- a/coreupdate/on-premises-deployment.md
+++ b/coreupdate/on-premises-deployment.md
@@ -98,9 +98,9 @@ DBMAXACTIVE: 100
 #ENABLE_PACKAGE_UPLOADS: true
 
 # (Optional) Enable if syncing with upstream CoreUpdate instances.
-# Zero value is disabled.
+# Value is minutes. Zero value is disabled.
 # This should be disabled if you plan to synchronize packages manually.
-UPSTREAM_SYNC_INTERVAL: 1
+UPSTREAM_SYNC_INTERVAL: 10
 
 # (Optional) enables TLS
 #TLS_CERT_FILE:


### PR DESCRIPTION

1) Change UPSTREAM_SYNC_INTERVAL so that if users copy and paste the config coreupdate will sync automatically with upstream

2) Add section on creating CoreOS ARM application (required when migrating/updating to 2.1.1)

3) Add section on syncing with public CoreUpdate 

