### PR TITLE
os/ec2: update link for china console

### DIFF
--- a/os/booting-on-ec2.md
+++ b/os/booting-on-ec2.md
@@ -29,7 +29,7 @@ Container Linux is designed to be [updated automatically](https://coreos.com/why
         </thead>
         <tbody>
         {% for region in site.data.alpha-channel.amis %}
-        {% capture region_domain %}{% if region.name == 'us-gov-west-1' %}amazonaws-us-gov.com{% else %}aws.amazon.com{% endif %}{% endcapture %}
+        {% capture region_domain %}{% if region.name == 'us-gov-west-1' %}amazonaws-us-gov.com{% elif region.name == 'cn-north-1' %}amazonaws.cn{% else %}aws.amazon.com{% endif %}{% endcapture %}
         <tr>
           <td rowspan="2">{{ region.name }}</td>
           <td class="dashed"><a href="http://aws.amazon.com/amazon-linux-ami/instance-type-matrix/">PV</a></td>


### PR DESCRIPTION
For the new cn-north-1 region, the default console link is wrong.