### PR TITLE
*: update info string in config fences

### DIFF
--- a/coreupdate/configure-machines.md
+++ b/coreupdate/configure-machines.md
@@ -24,7 +24,7 @@ For example, here is what the Alpha group looks like in CoreUpdate:
 
 Here's the Container Linux Config to use:
 
-```container-linux-config
+```yaml container-linux-config
 update:
   group:  alpha
   server: https://customer.update.core-os.net/v1/update/
@@ -40,7 +40,7 @@ For example, here is what "NYC Production" looks like in CoreUpdate:
 
 Here's the Container Linux Config to use:
 
-```container-linux-config
+```yaml container-linux-config
 update:
   group:  0a809ab1-c01c-4a6b-8ac8-6b17cb9bae09
   server: https://customer.update.core-os.net/v1/update/

--- a/etcd/etcd-live-cluster-reconfiguration.md
+++ b/etcd/etcd-live-cluster-reconfiguration.md
@@ -6,7 +6,7 @@ This document describes the reconfiguration or recovery of an etcd cluster runni
 
 When [a Container Linux Config][cl-configs] is used to configure an etcd member on a Container Linux node, it compiles a special `/etc/systemd/system/etcd-member.service.d/20-clct-etcd-member.conf` [drop-in unit file][drop-in]. That is, the Container Linux Config below:
 
-```container-linux-config
+```yaml container-linux-config
 etcd:
   advertise_client_urls: http://<PEER_ADDRESS>:2379
   initial_advertise_peer_urls: http://<PEER_ADDRESS>:2380
@@ -76,7 +76,7 @@ This section provides instructions on how to recover a failed etcd member. It is
 
 In this example, we use a 3-member etcd cluster with one failed node, that is still running and has maintained [quorum][majority]. An etcd member node might fail for several reasons: out of disk space, an incorrect reboot, or issues on the underlying system. Note that this example assumes you used [a Container Linux Config][cl-configs] with an etcd [discovery URL][etcd-discovery] to bootstrap your cluster, with the following default options:
 
-```container-linux-config
+```yaml container-linux-config
 etcd:
   advertise_client_urls: http://<PEER_ADDRESS>:2379
   initial_advertise_peer_urls: http://<PEER_ADDRESS>:2380

--- a/etcd/getting-started-with-etcd.md
+++ b/etcd/getting-started-with-etcd.md
@@ -18,7 +18,7 @@ To upgrade an existing etcd v2 cluster rather than deploy a new one, start with 
 
 A Container Linux Config can be used to set any etcd option, like in this example:
 
-```container-linux-config
+```yaml container-linux-config
 etcd:
   name:                        my-etcd-1
   listen_client_urls:          https://10.240.0.1:2379

--- a/etcd/tls-etcd-clients.md
+++ b/etcd/tls-etcd-clients.md
@@ -14,7 +14,7 @@ This document assumes three Container Linux nodes will be booted and will be run
 
 Flannel options can be specified in a Container Linux Config. For an example, this is a config that sets the etcd endpoints flannel will use and specifies tls resources to encrypt the connection:
 
-```container-linux-config
+```yaml container-linux-config
 flannel:
   etcd_endpoints: "https://172.16.0.101:2379,https://172.16.0.102:2379,https://172.16.0.103:2379"
   etcd_cafile:    /etc/ssl/etcd/ca.pem
@@ -28,7 +28,7 @@ Suppose you're using `/etc/etcd/ssl` instead, you will need to adjust the flanne
  
 A complete example would look like:
 
-```container-linux-config
+```yaml container-linux-config
 flannel:
   etcd_endpoints: "https://172.16.0.101:2379,https://172.16.0.102:2379,https://172.16.0.103:2379"
   etcd_cafile:    /etc/ssl/etcd/ca.pem
@@ -47,7 +47,7 @@ systemd:
 
 Due to the [deprecation of fleet][fleet-deprecation], Container Linux Configs don't have a convenient syntax for configuring fleet like for flannel. Fleet can still be easily configured however with the use of a systemd drop-in.
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: fleet.service
@@ -67,7 +67,7 @@ systemd:
 
 Example Container Linux Config excerpt for Locksmith configuration:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: locksmithd.service

--- a/flannel/flannel-config.md
+++ b/flannel/flannel-config.md
@@ -26,7 +26,7 @@ $ etcdctl set /coreos.com/network/config '{ "Network": "10.1.0.0/16" }'
 
 You can put this into a drop-in for flanneld.service via a Container Linux Config:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: flanneld.service
@@ -47,7 +47,7 @@ flannel uses UDP port 8285 for sending encapsulated IP packets. Make sure to ena
 
 The last step is to enable `flanneld.service` by creating the `flannel` section in our Container Linux Config. Options for flannel can be specified in this section.
 
-```container-linux-config
+```yaml container-linux-config
 flannel:
 ```
 
@@ -57,7 +57,7 @@ flannel:
 
 Flannel requires SSL certificates to communicate with a secure etcd cluster. By default, flannel looks for these certificates in `/etc/ssl/etcd`. To use different certificates, add `Environment=ETCD_SSL_DIR` to a drop-in file for `flanneld.service`. Use the following configuration snippet to achieve this:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: flanneld.service

--- a/fleet/launching-containers-fleet.md
+++ b/fleet/launching-containers-fleet.md
@@ -297,7 +297,7 @@ MachineMetadata=region=east
 
 On Container Linux, only fleet 0.11.x is available under /usr/bin. That one might be obsolete for users who want to try out more recent versions. In that case, users should define their own custom Container Linux Config to be able to run any version of fleet as they want. For example:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /opt/bin/fleet-wrapper

--- a/os/adding-swap.md
+++ b/os/adding-swap.md
@@ -81,7 +81,7 @@ The block device mounted at `/var/`, `/dev/sdXN`, is the correct filesystem type
 
 The following config sets up a 1GiB swapfile located at `/var/vm/swapfile1`.
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: swap.service

--- a/os/adding-users.md
+++ b/os/adding-users.md
@@ -6,7 +6,7 @@ You can create user accounts on a CoreOS Container Linux machine manually with `
 
 In your Container Linux Config, you can specify many [different parameters](https://github.com/coreos/container-linux-config-transpiler/blob/master/doc/configuration.md) for each user. Here's an example:
 
-```container-linux-config
+```yaml container-linux-config
 passwd:
   users:
     - name: core

--- a/os/booting-on-azure.md
+++ b/os/booting-on-azure.md
@@ -42,7 +42,7 @@ You can provide a raw Ignition config (produced from a Container Linux Config) t
 
 As an example, this config will configure and start etcd:
 
-```container-linux-config:azure
+```yaml container-linux-config:azure
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.

--- a/os/booting-on-digitalocean.md
+++ b/os/booting-on-digitalocean.md
@@ -78,7 +78,7 @@ You can provide a raw Ignition config to Container Linux via the DigitalOcean we
 
 As an example, this config will configure and start etcd:
 
-```container-linux-config:digitalocean
+```yaml container-linux-config:digitalocean
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.

--- a/os/booting-on-ec2.md
+++ b/os/booting-on-ec2.md
@@ -122,7 +122,7 @@ You can provide a raw Ignition config to Container Linux via the Amazon web cons
 
 As an example, this Container Linux Config will configure and start etcd:
 
-```container-linux-config:ec2
+```yaml container-linux-config:ec2
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.
@@ -146,7 +146,7 @@ etcd:
 
 Ephemeral disks and additional EBS volumes attached to instances can be mounted with a `.mount` unit. Amazon's block storage devices are attached differently [depending on the instance type](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/InstanceStorage.html#InstanceStoreDeviceNames). Here's the Container Linux Config to format and mount the first ephemeral disk, `xvdb`, on most instance types:
 
-```container-linux-config:ec2
+```yaml container-linux-config:ec2
 storage:
   filesystems:
     - mount:
@@ -258,7 +258,7 @@ First we need to create a security group to allow Container Linux instances to c
         </li>
         <li>
           Use <a href="provisioning.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
-          ```container-linux-config:ec2
+          ```yaml container-linux-config:ec2
           etcd:
             # All options get passed as command line flags to etcd.
             # Any information inside curly braces comes from the machine at boot time.
@@ -332,7 +332,7 @@ First we need to create a security group to allow Container Linux instances to c
         </li>
         <li>
           Use <a href="provisioning.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
-          ```container-linux-config:ec2
+          ```yaml container-linux-config:ec2
           etcd:
             # All options get passed as command line flags to etcd.
             # Any information inside curly braces comes from the machine at boot time.
@@ -406,7 +406,7 @@ First we need to create a security group to allow Container Linux instances to c
         </li>
         <li>
           Use <a href="provisioning.md">ct</a> to convert the following configuration into an Ignition config, and back in the EC2 dashboard, paste it into the "User Data" field.
-          ```container-linux-config:ec2
+          ```yaml container-linux-config:ec2
           etcd:
             # All options get passed as command line flags to etcd.
             # Any information inside curly braces comes from the machine at boot time.

--- a/os/booting-on-ecs.md
+++ b/os/booting-on-ecs.md
@@ -10,7 +10,7 @@ When booting your [Container Linux Machines on EC2](booting-on-ec2.md), configur
 
 Be sure to change `ECS_CLUSTER` to the cluster name you've configured via the ECS CLI or leave it empty for the default. Here's a full config example:
 
-```container-linux-config:ec2
+```yaml container-linux-config:ec2
 systemd:
  units:
    - name: amazon-ecs-agent.service

--- a/os/booting-on-google-compute-engine.md
+++ b/os/booting-on-google-compute-engine.md
@@ -16,7 +16,7 @@ You can provide a raw Ignition config to Container Linux via the Google Cloud co
 
 As an example, this config will configure and start etcd:
 
-```container-linux-config:gce
+```yaml container-linux-config:gce
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.
@@ -67,7 +67,7 @@ Create 3 instances from the image above using our Ignition from `example.ign`:
 
 Additional disks attached to instances can be mounted with a `.mount` unit. Each disk can be accessed via `/dev/disk/by-id/google-<disk-name>`. Here's the Container Linux Config to format and mount a disk called `database-backup`:
 
-```container-linux-config:gce
+```yaml container-linux-config:gce
 storage:
   filesystems:
     - mount:

--- a/os/booting-on-openstack.md
+++ b/os/booting-on-openstack.md
@@ -80,7 +80,7 @@ Container Linux allows you to configure machine parameters, launch systemd units
 
 A common Container Linux Config for OpenStack looks like:
 
-```container-linux-config:openstack-metadata
+```yaml container-linux-config:openstack-metadata
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.

--- a/os/booting-on-packet.md
+++ b/os/booting-on-packet.md
@@ -39,7 +39,7 @@ You can provide a raw Ignition config to Container Linux via Packet's userdata f
 
 As an example, this config will configure and start etcd:
 
-```container-linux-config:packet
+```yaml container-linux-config:packet
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.

--- a/os/booting-on-vmware.md
+++ b/os/booting-on-vmware.md
@@ -76,7 +76,7 @@ You can provide a raw Ignition config to Container Linux via VMware's [Guestinfo
 
 As an example, this config will start etcd:
 
-```container-linux-config
+```yaml container-linux-config
 etcd:
   # All options get passed as command line flags to etcd.
   # Any information inside curly braces comes from the machine at boot time.

--- a/os/booting-with-pxe.md
+++ b/os/booting-with-pxe.md
@@ -44,7 +44,7 @@ label coreos
 
 Here's a common config example which should be located at the URL from above:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: etcd2.service
@@ -147,7 +147,7 @@ If you plan on using Docker we recommend using a local ext4 filesystem with over
 
 For example, to setup an ext4 root filesystem on `/dev/sda`:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   disks:
   - device: /dev/sda
@@ -167,7 +167,7 @@ And add `root=/dev/sda1` or `root=LABEL=ROOT` to the kernel options as documente
 
 Similarly, to setup a btrfs root filesystem on `/dev/sda`:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   disks:
   - device: /dev/sda

--- a/os/cluster-discovery.md
+++ b/os/cluster-discovery.md
@@ -15,7 +15,7 @@ The discovery URL can be provided to each Container Linux machine via [Container
 
 Boot each one of the machines with identical Container Linux Config and they should be automatically clustered:
 
-```container-linux-config:ec2
+```yaml container-linux-config:ec2
 etcd:
   # generate a new token for each unique cluster from https://discovery.etcd.io/new?size=3
   # specify the initial size of your cluster with ?size=X

--- a/os/configuring-date-and-timezone.md
+++ b/os/configuring-date-and-timezone.md
@@ -121,7 +121,7 @@ $ sudo systemctl restart systemd-networkd
 
 NTP time sources can be set in `timesyncd.conf` with a [Container Linux Config][cl-configs] snippet like:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /etc/systemd/timesyncd.conf
@@ -147,7 +147,7 @@ $ sudo systemctl start ntpd
 
 or with this Container Linux Config snippet:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: systemd-timesyncd.service
@@ -179,7 +179,7 @@ $ sudo systemctl reload ntpd
 
 Or, in a [Container Linux Config][cl-configs]:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /etc/ntp.conf

--- a/os/configuring-dns.md
+++ b/os/configuring-dns.md
@@ -8,7 +8,7 @@ By default, DNS resolution on Container Linux is handled through `/etc/resolv.co
 
 Here is an example [Container Linux Config][cl-configs] snippet to do that:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /etc/nsswitch.conf

--- a/os/customize-etcd-unit.md
+++ b/os/customize-etcd-unit.md
@@ -8,7 +8,7 @@ etcd supports client certificates as a way to provide secure communication betwe
 
 Please follow the [instruction](generate-self-signed-certificates.md) to know how to create self-signed certificates and private keys.
 
-```container-linux-config
+```yaml container-linux-config
 etcd:
   # More settings are needed here for a functioning etcd daemon
   ca_file:        /path/to/CA.pem

--- a/os/customizing-docker.md
+++ b/os/customizing-docker.md
@@ -38,7 +38,7 @@ docker -H tcp://127.0.0.1:2375 ps
 
 To enable the remote API on every Container Linux machine in a cluster, use a [Container Linux Config][cl-configs]. We need to provide the new socket file and Docker's socket activation support will automatically start using the socket:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: docker-tcp.socket
@@ -162,7 +162,7 @@ docker images
 
 A Container Linux Config for Docker TLS authentication will look like:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /etc/docker/ca.pem
@@ -249,7 +249,7 @@ journalctl -u docker
 
 If you need to modify a flag across many machines, you can add the flag with a Container Linux Config:
 
-```container-linux-config
+```yaml container-linux-config
 docker:
   flags:
     - --debug
@@ -283,7 +283,7 @@ Proxy environment variables can also be set [system-wide][systemd-env-vars].
 
 The easiest way to use this proxy on all of your machines is via a Container Linux Config:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: docker.service
@@ -321,7 +321,7 @@ systemctl restart docker
 
 The easiest way to use these new ulimits on all of your machines is via a Container Linux Config:
 
-```container-linux-configs
+```yaml container-linux-configs
 systemd:
   units:
     - name: docker.service

--- a/os/customizing-sshd.md
+++ b/os/customizing-sshd.md
@@ -12,7 +12,7 @@ In this example we will disable logins for the `root` user, only allow login for
 
 [openssh-manual]: http://www.openssh.com/cgi-bin/man.cgi?query=sshd_config
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /etc/ssh/sshd_config
@@ -34,7 +34,7 @@ storage:
 
 Container Linux ships with socket-activated SSH by default. The configuration for this can be found at `/usr/lib/systemd/system/sshd.socket`. We're going to override some of the default settings for this in the Container Linux Config provided at boot:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: sshd.socket
@@ -185,7 +185,7 @@ Finally, execute a daemon-reload, stop the sshd.socket service, and start the ss
 
 The same configuration can be achieved and an actively listening sshd started with a Container Linux Config like:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: sshd.socket

--- a/os/install-debugging-tools.md
+++ b/os/install-debugging-tools.md
@@ -34,7 +34,7 @@ Pulling repository index.example.com/debug
 
 You can also specify this in a Container Linux Config:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /home/core/.toolboxrc

--- a/os/installing-to-disk.md
+++ b/os/installing-to-disk.md
@@ -76,7 +76,7 @@ After using the [Container Linux Config Transpiler][ct-docs] to produce an Ignit
 
 A Container Linux Config that specifies an SSH key for the `core` user but doesn't use any other parameters looks like:
 
-```container-linux-config
+```yaml container-linux-config
 passwd:
   users:
     - name: core
@@ -97,7 +97,7 @@ coreos-install -d /dev/sda -C stable -i ~/ignition.json
 
 This example will configure Container Linux components: etcd and flannel. You have to substitute `<PEER_ADDRESS>` to your host's IP or DNS address.
 
-```container-linux-config
+```yaml container-linux-config
 passwd:
   users:
     - name: core

--- a/os/iscsi.md
+++ b/os/iscsi.md
@@ -100,7 +100,7 @@ discovery.sendtargets.auth.password = my_secret_password
 
 ### The Container Linux Config
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: iscsid.service

--- a/os/migrating-to-clcs.md
+++ b/os/migrating-to-clcs.md
@@ -30,7 +30,7 @@ etcd can be configured in a more general way with a Container Linux Config. This
 
 This is done under the etcd section:
 
-```container-linux-config
+```yaml container-linux-config
 etcd:
     version: 3.1.6
 ```
@@ -39,7 +39,7 @@ Omitting the version specification declares that the unit file should use the ve
 
 Configuration options in this section can be provided the same way as they were in a cloud-config, with the exception of dashes (`-`) being replaced with underscores (`_`) in key names.
 
-```container-linux-config:gce
+```yaml container-linux-config:gce
 etcd:
   name:                        "{HOSTNAME}"
   advertise_client_urls:       "{PRIVATE_IPV4}:2379"
@@ -63,7 +63,7 @@ coreos:
 
 The flannel section in a Container Linux Config is used the same way, and a version can optionally be specified for flannel as well.
 
-```container-linux-config
+```yaml container-linux-config
 flannel:
   version:     0.7.0
   etcd_prefix: "/coreos.com/network2"
@@ -83,7 +83,7 @@ coreos:
 
 Locksmith can be configured in the same way under the locksmith section of a Container Linux Config, but some of the accepted options are slightly different. Also the reboot strategy is set in the locksmith section, instead of the update section. Check out the [Container Linux Config schema][ct-config] to see what options are available.
 
-```container-linux-config
+```yaml container-linux-config
 locksmith:
   reboot_strategy: "reboot"
   etcd_endpoints:  "http://example.com:2379"
@@ -104,7 +104,7 @@ coreos:
 
 In the update section in a Container Linux Config the group and server can be configured, but the reboot-strategy option has been moved under the locksmith section.
 
-```container-linux-config
+```yaml container-linux-config
 update:
   group:  "stable"
   server: "https://public.update.core-os.net/v1/update/"
@@ -163,7 +163,7 @@ One big difference in Container Linux Config compared to cloud-configs is that t
 
 _Note: in this example an `[Install]` section has been added so that the unit can be enabled._
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: "docker-redis.service"
@@ -185,7 +185,7 @@ systemd:
 
 Drop-in files can be provided for units in a Container Linux Config just like in a cloud-config.
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: "docker.service"
@@ -198,7 +198,7 @@ systemd:
 
 Existing units can also be enabled without configuration.
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: "etcd-member.service"
@@ -218,7 +218,7 @@ ssh_authorized_keys:
 
 In a Container Linux Config there is no analogous section to `ssh_authorized_keys`, but ssh keys for the core user can be set just as easily using the `passwd.users.*` section:
 
-```container-linux-config
+```yaml container-linux-config
 passwd:
   users:
     - name: core
@@ -238,7 +238,7 @@ hostname: "coreos1"
 
 The Container Linux Config is intentionally more generalized than a cloud-config, and there is no equivalent hostname section understood in a CL Config. Instead, set the hostname by writing it to `/etc/hostname` in a CL Config `storage.files.*` section.
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - filesystem: "root"
@@ -267,7 +267,7 @@ users:
 
 This same information can be added to the Container Linux Config in the `passwd.users.*` section.
 
-```container-linux-config
+```yaml container-linux-config
 passwd:
   users:
     - name:          "elroy"
@@ -298,7 +298,7 @@ write_files:
 
 This can be done in a Container Linux Config with the `storage.files.*` section.
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - filesystem: "root"
@@ -325,7 +325,7 @@ manage_etc_hosts: "localhost"
 
 There is no analogous section in a Container Linux Config, however the `/etc/hosts` file can be written in the `storage.files.*` section.
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - filesystem: "root"

--- a/os/mounting-storage.md
+++ b/os/mounting-storage.md
@@ -5,7 +5,7 @@ Container Linux Configs can be used to format and attach additional filesystems 
 
 Mount units name the source filesystem and target mount point, and optionally the filesystem type. *Systemd* mounts filesystems defined in such units at boot time. The following example mounts an [EC2 ephemeral disk](booting-on-ec2.md#instance-storage) at the node's `/media/ephemeral` directory, and is therefore named `media-ephemeral.mount`:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: media-ephemeral.mount
@@ -25,7 +25,7 @@ Docker containers can be very large and debugging a build process makes it easy 
 
 We're going to mount a ext4 device to `/var/lib/docker`, where Docker stores images. We can do this on the fly when the machines starts up with a oneshot unit that formats the drive and another one that runs afterwards to mount it. Be sure to hardcode the correct device or look for a device by label:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   filesystems:
     - name: ephemeral1
@@ -64,7 +64,7 @@ Container Linux [561.0.0](https://coreos.com/releases/#561.0.0) and later are in
 
 In this example, we are going to mount a new 25GB btrfs volume file to `/var/lib/docker`, and one can verify that Docker is using the btrfs storage driver once the Docker service has started by executing `sudo docker info`. We recommend allocating **no more than 85%** of the available disk space for a btrfs filesystem as journald will also require space on the host filesystem.
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: format-var-lib-docker.service
@@ -101,7 +101,7 @@ Note the declaration of `ConditionPathExists=!/var/lib/docker.btrfs`. Without th
 
 This Container Linux Config excerpt enables the NFS host monitor [`rpc.statd(8)`](http://linux.die.net/man/8/rpc.statd), then mounts an NFS export onto the Container Linux node's `/var/www`.
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: rpc-statd.service

--- a/os/network-config-with-networkd.md
+++ b/os/network-config-with-networkd.md
@@ -29,7 +29,7 @@ sudo systemctl restart systemd-networkd
 
 Setting up static networking in your Container Linux Config can be done by writing out the network unit. Be sure to modify the `[Match]` section with the name of your desired interface, and replace the IPs:
 
-```container-linux-config
+```yaml container-linux-config
 networkd:
   units:
     - name: 00-eth0.network
@@ -100,7 +100,7 @@ Destination=172.16.0.0/24
 
 To specify the same route in a Container Linux Config, create the systemd network unit there instead:
 
-```container-linux-config
+```yaml container-linux-config
 networkd:
   units:
     - name: 10-static.network
@@ -130,7 +130,7 @@ Gateway=10.0.1.1
 
 To do the same thing through a Container Linux Config:
 
-```container-linux-config
+```yaml container-linux-config
 networkd:
   units:
     - name: 20-multi_ip.network
@@ -175,7 +175,7 @@ journalctl -b -u systemd-networkd
 
 Define a [Drop-In][drop-ins] in a [Container Linux Config][cl-configs]:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: systemd-networkd.service

--- a/os/other-settings.md
+++ b/os/other-settings.md
@@ -10,7 +10,7 @@ echo nf_conntrack > /etc/modules-load.d/nf.conf
 
 Or, using a Container Linux Config:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /etc/modules-load.d/nf.conf
@@ -31,7 +31,7 @@ Further details can be found in the systemd man pages:
 
 This example Container Linux Config loads the `dummy` network interface module with an option specifying the number of interfaces the module should create when loaded (`numdummies=5`):
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /etc/modprobe.d/dummy.conf
@@ -57,7 +57,7 @@ sysctl --system
 
 Some parameters, such as the conntrack one above, are only available after the module they control has been loaded. To ensure any modules are loaded in advance use `modules-load.d` as described above. A complete Container Linux Config using both would look like:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /etc/modules-load.d/nf.conf
@@ -117,7 +117,7 @@ echo "This machine is dedicated to computing Pi" > /etc/motd.d/pi.conf
 
 Or via a Container Linux Config:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /etc/motd.d/pi.conf
@@ -138,7 +138,7 @@ echo -e '[Service]\nTTYVTDisallocate=no' > '/etc/systemd/system/getty@.service.d
 
 Or via a Container Linux Config:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: getty@.service

--- a/os/power-management.md
+++ b/os/power-management.md
@@ -23,7 +23,7 @@ echo "conservative" | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor 
 
 This can be configured with a [Container Linux Config][cl-configs] as well:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: cpu-governor.service

--- a/os/provisioning.md
+++ b/os/provisioning.md
@@ -10,20 +10,20 @@ The following examples demonstrate the simplicity of the Container Linux Config 
 
 This extremely simple Container Linux Config will fetch and run the current release of etcd:
 
-```container-linux-config:norender
+```yaml container-linux-config:norender
 etcd:
 ```
 
 Extend the definition to specify the version of etcd to run. The following example will provision a new Container Linux machine to fetch and run the etcd service, version 3.1.6:
 
-```container-linux-config:norender
+```yaml container-linux-config:norender
 etcd:
   version: 3.1.6
 ```
 
 Use variable replacement to configure the etcd service with the provisioning target's public and private IPv4 addresses, making it repeatable across a group of machines.
 
-```container-linux-config:norender
+```yaml container-linux-config:norender
 etcd:
   advertise_client_urls:       http://{PUBLIC_IPV4}:2379
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380
@@ -54,7 +54,7 @@ The Container Linux Config Transpiler abstracts the details of configuring Conta
 
 The following config will configure an etcd cluster using the machine's public and private IP addresses:
 
-```container-linux-config:norender
+```yaml container-linux-config:norender
 etcd:
   advertise_client_urls:       http://{PUBLIC_IPV4}:2379
   initial_advertise_peer_urls: http://{PRIVATE_IPV4}:2380

--- a/os/quickstart.md
+++ b/os/quickstart.md
@@ -44,7 +44,7 @@ If you used an example [Container Linux Config][cl-configs] or [cloud-config](ht
 
 A good starting point for a Container Linux Config would be something like:
 
-```container-linux-config
+```yaml container-linux-config
 etcd:
   discovery: https://discovery.etcd.io/<token>
 passwd:

--- a/os/reading-the-system-log.md
+++ b/os/reading-the-system-log.md
@@ -107,7 +107,7 @@ dmesg | grep systemd-journald
 
 Define a [Drop-In][drop-ins] in a [Container Linux Config][ct-configs]:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: systemd-journald.service

--- a/os/registry-authentication.md
+++ b/os/registry-authentication.md
@@ -180,7 +180,7 @@ More thorough information about configuring Mesos registry authentication can be
 
 Here is an example of using a Container Linux Config to write the .docker/config.json registry auth configuration file mentioned above to the appropriate path on the Container Linux node:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /home/core/.docker/config.json
@@ -200,7 +200,7 @@ storage:
 
 Container Linux Configs can also download a file from a remote location and verify its integrity with a SHA512 hash:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /home/core/.docker/config.json

--- a/os/scheduling-tasks-with-systemd-timers.md
+++ b/os/scheduling-tasks-with-systemd-timers.md
@@ -43,7 +43,7 @@ Unit=date.service
 
 Here you'll find an example Container Linux Config demonstrating how to install systemd timers:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: date.service

--- a/os/update-strategies.md
+++ b/os/update-strategies.md
@@ -16,7 +16,7 @@ It's important to note that updates are always downloaded to the passive partiti
 
 The reboot strategy can be set with a Container Linux Config:
 
-```container-linux-config
+```yaml container-linux-config
 locksmith:
   reboot_strategy: "etcd-lock"
 ```
@@ -72,7 +72,7 @@ In case when you don't want to install updates onto the passive partition and av
 
 If you wish to disable automatic updates permanently, use can configure this with a Container Linux Config. This example will stop `update-engine`, which executes the updates, and `locksmithd`, which coordinates reboots across the cluster:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: update-engine.service
@@ -86,7 +86,7 @@ systemd:
 Public Internet access is required to contact CoreUpdate and download new versions of Container Linux. If direct access is not available the `update-engine` service may be configured to use a HTTP or SOCKS proxy using curl-compatible environment variables, such as `HTTPS_PROXY` or `ALL_PROXY`.
 See [curl's documentation](http://curl.haxx.se/docs/manpage.html#ALLPROXY) for details.
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: update-engine.service

--- a/os/using-environment-variables-in-systemd-units.md
+++ b/os/using-environment-variables-in-systemd-units.md
@@ -81,7 +81,7 @@ This unit file will run nginx Docker container and bind it to specific IP addres
 
 You can define system wide environment variables using a [Container Linux Config][cl-configs] as explained below:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /etc/systemd/system.conf.d/10-default-env.conf

--- a/os/using-systemd-and-udev-rules.md
+++ b/os/using-systemd-and-udev-rules.md
@@ -41,7 +41,7 @@ That rule means that udev will trigger `device-attach.service` systemd unit on a
 
 To use the unit and udev rule with a Container Linux Config, modify this example as needed:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /etc/udev/rules.d/01-block.rules 

--- a/os/using-systemd-drop-in-units.md
+++ b/os/using-systemd-drop-in-units.md
@@ -92,7 +92,7 @@ RestartSec=60s
 
 Container Linux Config example:
 
-```container-linux-config
+```yaml container-linux-config
 systemd:
   units:
     - name: fleet.service

--- a/quay-enterprise/configure-machines.md
+++ b/quay-enterprise/configure-machines.md
@@ -73,7 +73,7 @@ To use a specific pull secret as the default in a specific namespace, you can cr
 
 A snippet to configure the credentials via `files` in a Container Linux Config looks like:
 
-```container-linux-config
+```yaml container-linux-config
 storage:
   files:
     - path: /root/.dockercfg


### PR DESCRIPTION
This will allow the blocks to render correctly on both GitHub and
coreos.com.