### PR TITLE
Quay Enterprise: RBAC on tectonic documentation for 1.6

### DIFF
--- a/quay-enterprise/tectonic/files/quay-servicetoken-role-binding-k8s1-6.yaml
+++ b/quay-enterprise/tectonic/files/quay-servicetoken-role-binding-k8s1-6.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: quay-enterprise-secret-writer
+  namespace: quay-enterprise
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: quay-enterprise-serviceaccount
+subjects:
+- kind: ServiceAccount
+  name: default

--- a/quay-enterprise/tectonic/files/quay-servicetoken-role-k8s1-6.yaml
+++ b/quay-enterprise/tectonic/files/quay-servicetoken-role-k8s1-6.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:  
+  name: quay-enterprise-serviceaccount
+  namespace: quay-enterprise
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - put
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get

--- a/quay-enterprise/tectonic/index.md
+++ b/quay-enterprise/tectonic/index.md
@@ -33,7 +33,12 @@ Quay Enterprise has native Kubernetes integrations. These integrations require S
 
 Kubernetes API has minor changes between versions 1.4 and 1.5, Download appropiate versions of Role Based Access Control (RBAC) Policies.
 
-### Tectonic v1.5.x RBAC Policies
+### Tectonic v1.6.x RBAC Policies 
+
+- [quay-servicetoken-role.yaml](files/quay-servicetoken-role-k8s1-6.yaml)
+- [quay-servicetoken-role-binding.yaml](files/quay-servicetoken-role-binding-k8s1-6.yaml)
+
+### Tectonic v1.5.x RBAC Policies 
 
 - [quay-servicetoken-role.yaml](files/quay-servicetoken-role.yaml)
 - [quay-servicetoken-role-binding.yaml](files/quay-servicetoken-role-binding.yaml)


### PR DESCRIPTION
Updated documentation for QE on Tectonic 1.6

Tectonic 1.5 manifests works if kubectl version 1.6 is used. During this `kubectl` seem to transform `apiVersion: rbac.authorization.k8s.io/v1alpha1` to `apiVersion: rbac.authorization.k8s.io/v1beta1` . 

Created 1.6 specific manifests for cases where user may not be using kubectl or an older version of kubectl. 