### PR TITLE
os/sdk-modifying-coreos: removed repo and cros_sdk instructions

### DIFF
--- a/os/sdk-building-production-images.md
+++ b/os/sdk-building-production-images.md
@@ -33,7 +33,7 @@ That was far too easy, if you need to do it the hard way try this:
  4. Update `version.txt` with the desired version number.
     * COREOS_BUILD is the major version number, and should be the number of days since July 1st, 2013. COREOS_BRANCH should start at 0 and is incremented for every normal release based on a particular COREOS_BUILD version. COREOS_PATCH is reserved for exceptional situations such as emergency manual releases and should normally be 0.
     * The complete version string is COREOS_BUILD.COREOS_BRANCH.COREOS_PATCH
-    * COREOS_SDK_VERSION should be the complete version string of an existing build. The `cros_sdk` uses this to pick what SDK tarball to use when creating a fresh chroot and provides a fallback set of binary packages to use when the current release's packages are unavailable. Usually it will be one release behind COREOS_BUILD.
+    * COREOS_SDK_VERSION should be the complete version string of an existing build. `cork` uses this to pick what SDK tarball to use when creating a fresh chroot and provides a fallback set of binary packages to use when the current release's packages are unavailable. Usually it will be one release behind COREOS_BUILD.
  5. Generate a release manifest: `repo manifest -r -o build-$BUILD.xml` where `$BUILD` is the current value of COREOS_BUILD in `version.txt`.
  6. Update `release.xml`: `ln -sf build-$BUILD.xml release.xml`
  7. Commit! `git add build-$BUILD.xml; git commit -a`

--- a/os/sdk-modifying-coreos.md
+++ b/os/sdk-modifying-coreos.md
@@ -27,9 +27,9 @@ git config --global user.name "Your Name"
 
 **NOTE**: Do the git configuration as a normal user and not with sudo.
 
-### Option 1: Using Cork
+### Using Cork
 
-The `cork` utility, included in the CoreOS [mantle](https://github.com/coreos/mantle) project, can be used to create and work with an SDK chroot.
+The `cork` utility, included in the CoreOS [mantle](https://github.com/coreos/mantle) project, is used to create and work with an SDK chroot.
 
 In order to use this utility, you must additionally have the [golang](https://golang.org/) toolchain installed and configured correctly.
 
@@ -47,7 +47,7 @@ export PATH=$PATH:$HOME/bin
 You may want to add the `PATH` export to your shell profile (e.g. `.bashrc`).
 
 
-Next, the cork utility can be used to create an SDK chroot:
+Next, use the cork utility to create a project directory. This will hold all of your git repos and the SDK chroot. A few gigabytes of space will be necessary.
 
 ```sh
 mkdir coreos-sdk
@@ -61,56 +61,7 @@ cork enter
 
 To use the SDK chroot in the future, run `cork enter` from the above directory.
 
-### Option 2: using repo and cros\_sdk
-
-#### Install Repo
-
-The `repo` utility helps to manage the collection of git repositories that makes up Container Linux. 
-
-For newer Debian, Ubuntu, and other Debian based systems, install the repo package from your distro:
-
-    sudo apt-get install repo
-
-For systems without a packaged repo download it and add it to `$PATH`:
-
-```sh
-mkdir ~/bin
-export PATH="$PATH:$HOME/bin"
-curl https://storage.googleapis.com/git-repo-downloads/repo > ~/bin/repo
-chmod a+x ~/bin/repo
-```
-
-You may want to add the `PATH` export to `.bashrc` or `/etc/profile.d/` so that you don’t need to set `$PATH` in every new shell.
-
-#### Bootstrap the SDK chroot
-
-Create a project directory. This will hold all of your git repos and the SDK chroot. A few gigabytes of space will be necessary.
-
-```sh
-mkdir coreos; cd coreos
-```
-
-Initialize the .repo directory with the manifest that describes all of the git repos required to get started.
-
-```sh
-repo init -u https://github.com/coreos/manifest.git
-```
-
-Synchronize all of the required git repos from the manifest.
-
-```sh
-repo sync
-```
-
-#### Use cros\_sdk to setup the chroot
-
-Download and enter the SDK chroot which contains all of the compilers and tooling.
-
-```sh
-./chromite/bin/cros_sdk
-```
-
-**WARNING:** To delete the SDK chroot, use `./chromite/bin/cros_sdk --delete`. Otherwise, you will delete `/dev` entries that are `bind`-mounted into the chroot.
+**WARNING:** To delete the SDK chroot, use `cork delete`. Otherwise, you will delete `/dev` entries that are `bind`-mounted into the chroot.
 
 ### Using QEMU for cross-compiling
 
@@ -141,7 +92,7 @@ This will install the configuration file `/etc/binfmt.d/qemu-aarch64.conf`, whic
 
 ### Building an image
 
-After entering the chroot via `cork` or `cros_sdk` for the first time, you should set user `core`'s password:
+After entering the chroot via `cork` for the first time, you should set user `core`'s password:
 
 ```sh
 ./set_shared_user_password.sh

--- a/os/sdk-modifying-coreos.md
+++ b/os/sdk-modifying-coreos.md
@@ -31,17 +31,32 @@ git config --global user.name "Your Name"
 
 The `cork` utility, included in the CoreOS [mantle](https://github.com/coreos/mantle) project, is used to create and work with an SDK chroot.
 
-In order to use this utility, you must additionally have the [golang](https://golang.org/) toolchain installed and configured correctly.
-
-First, install the cork utility:
+First, download the cork utility and verify it with the signature:
 
 ```sh
-git clone https://github.com/coreos/mantle
-cd mantle
-./build cork
-mkdir ~/bin
-mv ./bin/cork ~/bin
-export PATH=$PATH:$HOME/bin
+curl -L -o cork https://github.com/coreos/mantle/releases/download/v0.7.0/cork-0.7.0-amd64
+curl -L -o cork.sig https://github.com/coreos/mantle/releases/download/v0.7.0/cork-0.7.0-amd64.sig
+gpg --receive-keys 9CEB8FE6B4F1E9E752F61C82CDDE268EBB729EC7
+gpg --verify cork.sig cork
+```
+
+The `gpg --verify` command should output something like this:
+
+```
+gpg: Signature made Thu 31 Aug 2017 02:47:22 PM PDT
+gpg:                using RSA key 9CEB8FE6B4F1E9E752F61C82CDDE268EBB729EC7
+gpg: Good signature from "CoreOS Application Signing Key <security@coreos.com>" [unknown]
+Primary key fingerprint: 18AD 5014 C99E F7E3 BA5F  6CE9 50BD D3E0 FC8A 365E
+     Subkey fingerprint: 9CEB 8FE6 B4F1 E9E7 52F6  1C82 CDDE 268E BB72 9EC7
+```
+
+Then proceed with the installation of the cork binary to a location on your path:
+
+```sh
+chmod +x cork
+mkdir -p ~/.local/bin
+mv cork ~/.local/bin
+export PATH=$PATH:$HOME/.local/bin
 ```
 
 You may want to add the `PATH` export to your shell profile (e.g. `.bashrc`).
@@ -60,8 +75,6 @@ cork enter
 
 
 To use the SDK chroot in the future, run `cork enter` from the above directory.
-
-**WARNING:** To delete the SDK chroot, use `cork delete`. Otherwise, you will delete `/dev` entries that are `bind`-mounted into the chroot.
 
 ### Using QEMU for cross-compiling
 


### PR DESCRIPTION
The "option 2" section of the sdk instructions is apparently obsolete. cc @euank 