### PR TITLE
Fixed wording in geo-replication.md

### DIFF
--- a/quay-enterprise/geo-replication.md
+++ b/quay-enterprise/geo-replication.md
@@ -35,6 +35,6 @@ Sign in to a super user account and visit `http://yourregister/superuser` to vie
     docker run -d -p 443:443 -p 80:80 -v /conf/stack:/conf/stack -e QUAY_DISTRIBUTED_STORAGE_PREFERENCE=europestorage quay.io/coreos/quay:versiontag
     ```
 
-    *NOTE: The value of the environment variable specified must match the name of a storage engine as defined in the config panel*
+    *NOTE: The value of the environment variable specified must match the name of a Location ID as defined in the config panel*
 
 3. Restart all Quay Enterprise containers


### PR DESCRIPTION
Altered the "*Note:" at the end of the document to use the same terminology as the Quay Enterprise Superuser panel. That panel refers to the defined storage options as "Location IDs".