### PR TITLE
os/mounting-storage: Drop unnecessary enablement of rpc.statd

### DIFF
--- a/os/mounting-storage.md
+++ b/os/mounting-storage.md
@@ -99,13 +99,11 @@ Note the declaration of `ConditionPathExists=!/var/lib/docker.btrfs`. Without th
 
 ## Mounting NFS exports
 
-This Container Linux Config excerpt enables the NFS host monitor [`rpc.statd(8)`](http://linux.die.net/man/8/rpc.statd), then mounts an NFS export onto the Container Linux node's `/var/www`.
+This Container Linux Config excerpt mounts an NFS export onto the Container Linux node's `/var/www`.
 
 ```yaml container-linux-config
 systemd:
   units:
-    - name: rpc-statd.service
-      enable: true
     - name: var-www.mount
       enable: true
       contents: |


### PR DESCRIPTION
rpc-statd.service has no `Install` section, so the `enable` directive doesn't do anything. mount.nfs(8) automatically starts rpc.statd if required.

Partially addresses https://github.com/coreos/bugs/issues/2038.