### PR TITLE
os/booting-with-{ipxe,pxe}: document support for s3

### DIFF
--- a/os/booting-with-ipxe.md
+++ b/os/booting-with-ipxe.md
@@ -22,7 +22,7 @@ When configuring the Container Linux iPXE boot script there are a few kernel opt
 - **console**: Enable kernel output and a login prompt on a given tty. The default, `tty0`, generally maps to VGA. Can be used multiple times, e.g. `console=tty0 console=ttyS0`
 - **coreos.autologin**: Drop directly to a shell on a given console without prompting for a password. Useful for troubleshooting but use with caution. For any console that doesn't normally get a login prompt by default be sure to combine with the `console` option, e.g. `console=tty0 console=ttyS0 coreos.autologin=tty1 coreos.autologin=ttyS0`. Without any argument it enables access on all consoles. Note that for the VGA console the login prompts are on virtual terminals (`tty1`, `tty2`, etc), not the VGA console itself (`tty0`).
 - **coreos.first_boot=1**: Download an Ignition config and use it to provision your booted system. Ignition configs are generated from Container Linux Configs. See the [config transpiler documentation][cl-configs] for more information. If a local filesystem is used for the root partition, pass this parameter only on the first boot.
-- **coreos.config.url**: Download the Ignition config from the specified URL. `http`, `https`, and `tftp` schemes are supported.
+- **coreos.config.url**: Download the Ignition config from the specified URL. `http`, `https`, `s3`, and `tftp` schemes are supported.
 
 ### Choose a Channel
 

--- a/os/booting-with-pxe.md
+++ b/os/booting-with-pxe.md
@@ -24,7 +24,7 @@ When configuring the Container Linux pxelinux.cfg there are a few kernel options
 - **console**: Enable kernel output and a login prompt on a given tty. The default, `tty0`, generally maps to VGA. Can be used multiple times, e.g. `console=tty0 console=ttyS0`
 - **coreos.autologin**: Drop directly to a shell on a given console without prompting for a password. Useful for troubleshooting but use with caution. For any console that doesn't normally get a login prompt by default be sure to combine with the `console` option, e.g. `console=tty0 console=ttyS0 coreos.autologin=tty1 coreos.autologin=ttyS0`. Without any argument it enables access on all consoles. Note that for the VGA console the login prompts are on virtual terminals (`tty1`, `tty2`, etc), not the VGA console itself (`tty0`).
 - **coreos.first_boot=1**: Download an Ignition config and use it to provision your booted system. Ignition configs are generated from Container Linux Configs. See the [config transpiler documentation][cl-configs] for more information. If a local filesystem is used for the root partition, pass this parameter only on the first boot.
-- **coreos.config.url**: Download the Ignition config from the specified URL. `http`, `https`, and `tftp` schemes are supported.
+- **coreos.config.url**: Download the Ignition config from the specified URL. `http`, `https`, `s3`, and `tftp` schemes are supported.
 
 This is an example pxelinux.cfg file that assumes Container Linux is the only option. You should be able to copy this verbatim into `/var/lib/tftpboot/pxelinux.cfg/default` after providing an Ignition config URL:
 


### PR DESCRIPTION
Ignition configs can now be fetched over s3. This commit adds mention
of that to the ipxe and pxe docs for the OS.

Fixes https://github.com/coreos/bugs/issues/2067