### PR TITLE
os/kernel-modules: drop the branch checkout step

### DIFF
--- a/os/kernel-modules.md
+++ b/os/kernel-modules.md
@@ -63,17 +63,10 @@ sudo systemd-nspawn \
     --image=coreos_developer_container.bin
 ```
 
-Now, inside the container, fetch the Container Linux package definitions and check out the current version's branch.
+Now, inside the container, fetch the Container Linux package definitions, then download and prepare the Linux kernel source for building external modules.
 
 ```sh
 emerge-gitclone
-. /usr/share/coreos/release
-git -C /var/lib/portage/coreos-overlay checkout build-${COREOS_RELEASE_VERSION%%.*}
-```
-
-Still inside the container, download and prepare the Linux kernel source for building external modules.
-
-```sh
 emerge -gKv coreos-sources
 gzip -cd /proc/config.gz > /usr/src/linux/.config
 make -C /usr/src/linux modules_prepare


### PR DESCRIPTION
This has been automated in the `emerge-gitclone` command, since all recent releases now have overlay branches created at tag time.