### PR TITLE
os: fixed update-ssh-keys usage

### DIFF
--- a/os/adding-users.md
+++ b/os/adding-users.md
@@ -40,7 +40,7 @@ passwd: password changed.
 To assign an SSH key, run:
 
 ```sh
-update-ssh-keys -u user1 user1.pem
+update-ssh-keys -u user1 -a user1 user1.pem
 ```
 
 ## Grant sudo Access


### PR DESCRIPTION
The usage originally in this doc didn't actually add ssh keys for a user, it just syncs `authorized_keys.d` to  the `authorized_keys` file (https://github.com/coreos/init/blob/9008a3d0457d7e0a303fbee9610723b1c5a66cf2/bin/update-ssh-keys#L27). Adding the `-a NAME` flag does actually add the ssh key as described. 