### PR TITLE
Add DNS configuration necessary for proper static config

### DIFF
--- a/os/network-config-with-networkd.md
+++ b/os/network-config-with-networkd.md
@@ -17,6 +17,7 @@ Name=enp2s0
 [Network]
 Address=192.168.0.15/24
 Gateway=192.168.0.1
+DNS=192.168.10
 ```
 
 Place the file in `/etc/systemd/network/`. To apply the configuration, run:

--- a/os/network-config-with-networkd.md
+++ b/os/network-config-with-networkd.md
@@ -17,7 +17,7 @@ Name=enp2s0
 [Network]
 Address=192.168.0.15/24
 Gateway=192.168.0.1
-DNS=192.168.10
+DNS=1.2.3.4
 ```
 
 Place the file in `/etc/systemd/network/`. To apply the configuration, run:
@@ -57,6 +57,7 @@ Name=enp2s0
 [Network]
 Address=192.168.0.15/24
 Gateway=192.168.0.1
+DNS=1.2.3.4
 ```
 
 Put your settings-of-last-resort in `20-dhcp.network`. For example, any interfaces matching `en*` that weren't matched in `10-static.network` will be configured with DHCP:


### PR DESCRIPTION
Without some DNS server, this static config won't allow a host to access much of anything. This config can be verified  [here](https://www.freedesktop.org/software/systemd/man/systemd.network.html#[Network]%20Section%20Options)