### PR TITLE
os/booting-with-{pxe,ipxe,iso}: increase minimum RAM

### DIFF
--- a/os/booting-with-ipxe.md
+++ b/os/booting-with-ipxe.md
@@ -2,7 +2,7 @@
 
 These instructions will walk you through booting Container Linux via iPXE on real or virtual hardware. By default, this will run Container Linux completely out of RAM. Container Linux can also be [installed to disk](installing-to-disk.md).
 
-A mininum of 1024M of RAM is required to boot Container Linux via PXE.
+A mininum of 2 GB of RAM is required to boot Container Linux via PXE.
 
 ## Configuring iPXE
 

--- a/os/booting-with-iso.md
+++ b/os/booting-with-iso.md
@@ -43,7 +43,7 @@ The latest Container Linux ISOs can be downloaded from the image storage site:
 
 1. UEFI boot is not currently supported. Boot the system in BIOS compatibility mode.
 2. There is no straightforward way to provide an [Ignition config][cl-configs].
-3. A mininum of 1024M of RAM is required to boot Container Linux via ISO.
+3. A mininum of 2 GB of RAM is required to boot Container Linux via ISO.
 
 ## Install to disk
 

--- a/os/booting-with-pxe.md
+++ b/os/booting-with-pxe.md
@@ -2,7 +2,7 @@
 
 These instructions will walk you through booting Container Linux via PXE on real or virtual hardware. By default, this will run Container Linux completely out of RAM. Container Linux can also be [installed to disk](installing-to-disk.md).
 
-A mininum of 1024M of RAM is required to boot Container Linux via PXE.
+A mininum of 2 GB of RAM is required to boot Container Linux via PXE.
 
 ## Configuring pxelinux
 


### PR DESCRIPTION
1 GiB is no longer sufficient now that there are multiple docker packages in the image. We don't actually need the full 2 GiB, but use round numbers.