### PR TITLE
os: remove mention of blog posts in vmware docs

### DIFF
--- a/ignition/metadata.md
+++ b/ignition/metadata.md
@@ -8,7 +8,7 @@ Each of these examples is written in version 2.0.0 of the config. Ensure that an
 
 This config will write a systemd drop-in (shown below) for the etcd2.service. The drop-in modifies the ExecStart option, adding a few flags to etcd2's invocation. These flags use variables defined by coreos-metadata.service to change the interfaces on which etcd2 listens. coreos-metadata is provided by Container Linux and will read the appropriate metadata for the cloud environment (AWS in this example) and write the results to `/run/metadata/coreos`. For more information on the supported platforms and environment variables, refer to the [coreos-metadata README][metadata-readme].
 
-```json
+```json ignition-config
 {
   "ignition": { "version": "2.0.0" },
   "systemd": {
@@ -26,7 +26,7 @@ This config will write a systemd drop-in (shown below) for the etcd2.service. Th
 
 ### metadata.conf
 
-```
+```ini
 [Unit]
 Requires=coreos-metadata.service
 After=coreos-metadata.service
@@ -48,7 +48,7 @@ When Container Linux is used outside of a supported cloud environment (for examp
 
 This config will write a single service unit with the contents of a metadata agent service (shown below). This unit will not start on its own, because it is not enabled and is not a dependency of any other units. This metadata agent will fetch instance metadata from EC2 and save it to an ephemeral file.
 
-```json
+```json ignition-config
 {
   "ignition": { "version": "2.0.0" },
   "systemd": {
@@ -62,7 +62,7 @@ This config will write a single service unit with the contents of a metadata age
 
 ### metadata.service
 
-```
+```ini
 [Unit]
 Description=EC2 metadata agent
 

--- a/ignition/network-configuration.md
+++ b/ignition/network-configuration.md
@@ -8,7 +8,7 @@ Each of these examples is written in version 2.0.0 of the config. Ensure that an
 
 In this example, the network interface with the name "eth0" will be given the IP address 10.0.1.7. A typical interface will need more configuration and may use all of the options of a [network unit][network].
 
-```json
+```json ignition-config
 {
   "ignition": { "version": "2.0.0" },
   "networkd": {
@@ -22,7 +22,7 @@ In this example, the network interface with the name "eth0" will be given the IP
 
 This configuration will instruct Ignition to create a single network unit named "00-eth0.network" with the contents:
 
-```
+```ini
 [Match]
 Name=eth0
 
@@ -51,7 +51,7 @@ This format can be specified multiple times to apply unique static configuration
 
 In this example, all of the network interfaces whose names begin with "eth" will be bonded together to form "bond0". This new interface will then be configured to use DHCP.
 
-```json
+```json ignition-config
 {
   "ignition": { "version": "2.0.0" },
   "networkd": {

--- a/os/booting-on-vmware.md
+++ b/os/booting-on-vmware.md
@@ -142,7 +142,7 @@ guestinfo.coreos.config.data.encoding = "base64"
 
 This example will be decoded into:
 
-```json
+```json ignition-config
 {
   "ignition": { "version": "2.0.0" }
 }

--- a/os/booting-on-vmware.md
+++ b/os/booting-on-vmware.md
@@ -122,8 +122,6 @@ vmware-cmd /vmfs/volumes/[...]/<VMNAME>/<VMNAME>.vmx setguestinfo guestinfo.<pro
 
 Guestinfo configuration set via the VMware API or with `vmtoolsd` from within the Container Linux guest itself are stored in VM process memory and are lost on VM shutdown or reboot.
 
-[This blog post][vmware-use-guestinfo] has some useful details about the guestinfo interface, while Robert Labrie's blog provides a practicum specific to [using VMware guestinfo to configure Container Linux VMs][labrie-guestinfo].
-
 ### Defining the Ignition config in Guestinfo
 
 If the `guestinfo.coreos.config.data` property is set, Ignition will apply the referenced config on first boot.
@@ -177,6 +175,4 @@ Now that you have a machine booted, it's time to explore. Check out the [Contain
 [install]: installing-to-disk.md
 [vcloud director]: http://blogs.vmware.com/vsphere/2012/06/leveraging-vapp-vm-custom-properties-in-vcloud-director.html
 [ovf-selfconfig]: http://blogs.vmware.com/vapp/2009/07/selfconfiguration-and-the-ovf-environment.html
-[vmware-use-guestinfo]: http://blog-lrivallain.rhcloud.com/2014/08/15/vmware-use-guestinfo-variables-to-customize-guest-os/
-[labrie-guestinfo]: https://robertlabrie.wordpress.com/2015/09/27/coreos-on-vmware-using-vmware-guestinfo-api/
 [guestinfo]: #vmware-guestinfo-interface

--- a/os/provisioning.md
+++ b/os/provisioning.md
@@ -83,7 +83,7 @@ $ ct --platform=ec2 < example.yml
 
 This time, `ct` successfully runs and produces the following Ignition Config:
 
-```ignition-config
+```json ignition-config
 {
   "ignition": { "version": "2.0.0" },
   "systemd": {


### PR DESCRIPTION
vmware-use-guestinfo is now a broken link (404).
labrie-guestinfo details how to use the cloudinit-specific variables.