### PR TITLE
qe: fix quay-builder ssl cert command

### DIFF
--- a/quay-enterprise/build-support.md
+++ b/quay-enterprise/build-support.md
@@ -45,15 +45,15 @@ Use the environment variable `SERVER` to tell the worker the hostname at which Q
 Here's what the full command looks like:
 
 ```sh
-docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/quay-builder:v2.6.0
+docker run --restart on-failure -e SERVER=ws://myquayenterprise -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/quay-builder:v2.6.0
 ```
 
 When the container starts, each build worker will auto-register and start building containers once a job is triggered and it is assigned to a worker.
 
-If Quay is setup to use a SSL certificate that is not globally trusted, for example a self-signed certificate, Quay's public SSL certificates must be mounted onto the `quay-builder` container's SSL trust store. An example command to mount a certificate directory found at the host's `/path/to/ssl` looks like:
+If Quay is setup to use a SSL certificate that is not globally trusted, for example a self-signed certificate, Quay's public SSL certificates must be mounted onto the `quay-builder` container's SSL trust store. An example command to mount a certificate found at the host's `/path/to/ssl/rootCA.pem` looks like:
 
 ```sh
-docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /path/to/ssl:/usr/local/share/ca-certificates -v /var/run/docker.sock:/var/run/docker.sock quay.io/coreos/quay-builder:v2.6.0 /bin/sh -c "/usr/sbin/update-ca-certificates ; /quay-builder"
+docker run --restart on-failure -e SERVER=wss://myquayenterprise -v /path/to/ssl/rootCA.pem:/usr/local/share/ca-certificates/rootCA.pem -v /var/run/docker.sock:/var/run/docker.sock --entrypoint /bin/sh quay.io/coreos/quay-builder:v2.6.0 -c '/usr/sbin/update-ca-certificates && quay-builder'
 ```
 
 ### Setup GitHub build (optional)


### PR DESCRIPTION
This command change is required as the current command does not properly load the self-signed certificate into the builder. Also removed an 's' to provide an example of connecting to a reg not protected by ssl. 