### PR TITLE
docs: add working with github landing page

### DIFF
--- a/quay-enterprise/quay-github.md
+++ b/quay-enterprise/quay-github.md
@@ -1,0 +1,18 @@
+# Working with GitHub
+
+Use these guides to:
+
+* [Authenticate users with GitHub][auth-users]
+* [Use GitHub to trigger builds][trigger-builds]
+* [Use Git triggers and submodules][triggers-submodules]
+* [Create GitHub read-only build triggers][ro-triggers]
+* [Use OAuth to access GitHub][oauth-access]
+* [Use OAuth with BitBucket][oauth-bitbucket]
+
+
+[auth-users]: github-auth.md
+[trigger-builds]: github-build.md
+[triggers-submodules]: http://docs.quay.io/guides/git-submodules.html
+[ro-triggers]: http://docs.quay.io/guides/github-read-only.html
+[oauth-access]: github-app.md
+[oauth-bitbucket]: bitbucket-app.md

--- a/quay-enterprise/quay-github.md
+++ b/quay-enterprise/quay-github.md
@@ -7,7 +7,6 @@ Use these guides to:
 * [Use Git triggers and submodules][triggers-submodules]
 * [Create GitHub read-only build triggers][ro-triggers]
 * [Use OAuth to access GitHub][oauth-access]
-* [Use OAuth with BitBucket][oauth-bitbucket]
 
 
 [auth-users]: github-auth.md
@@ -15,4 +14,3 @@ Use these guides to:
 [triggers-submodules]: http://docs.quay.io/guides/git-submodules.html
 [ro-triggers]: http://docs.quay.io/guides/github-read-only.html
 [oauth-access]: github-app.md
-[oauth-bitbucket]: bitbucket-app.md


### PR DESCRIPTION
This page may no longer be necessary. Just knocking it out in case.