### PR TITLE
booting-on-virtualbox: Fixed syntax and grammar errors

### DIFF
--- a/os/booting-on-virtualbox.md
+++ b/os/booting-on-virtualbox.md
@@ -4,18 +4,18 @@ These instructions will walk you through running Container Linux on Oracle VM Vi
 
 ## Building the virtual disk
 
-There is a script that simplify the VDI building. It downloads a bare-metal image, verifies it with GPG, and converts the image to VirtualBox format.
+There is a script that simplifies building the VDI image. It downloads a bare-metal image, verifies it with GPG, and converts that image to a VDI image.
 
 The script is located on [GitHub](https://github.com/coreos/scripts/blob/master/contrib/create-coreos-vdi). The running host must support VirtualBox tools.
 
-As first step, you must download and make it executable.
+As first step, you must download the script and make it executable.
 
 ```sh
 wget https://raw.githubusercontent.com/coreos/scripts/master/contrib/create-coreos-vdi
 chmod +x create-coreos-vdi
 ```
 
-To run the script you can specify a destination location and the Container Linux version.
+To run the script, you can specify a destination location and the Container Linux version.
 
 ```sh
 ./create-coreos-vdi -d /data/VirtualBox/Templates
@@ -56,7 +56,7 @@ Choose a channel to base your disk image on. Specific versions of Container Linu
   </div>
 </div>
 
-After the script is finished successfully, will be available at the specified destination location the Container Linux image or at current location. The file name will be something like:
+After the script has finished successfully, the Container Linux image will be available at the specified destination location or at the current location. The file name will be something like:
 
 ```
 coreos_production_stable.vdi
@@ -70,7 +70,7 @@ Note that the config-drive standard was originally an OpenStack feature, which i
 
 For more information on customization that can be done with cloud-config, head on over to the [cloud-config guide](https://github.com/coreos/coreos-cloudinit/blob/master/Documentation/cloud-config.md).
 
-You need a config-drive to configure at least one SSH key to access the virtual machine. If you are in hurry you can create a basic config-drive with following steps.
+You need a config-drive to configure at least one SSH key to access the virtual machine. If you are in hurry, you can create a basic config-drive with following steps:
 
 ```sh
 wget https://raw.github.com/coreos/scripts/master/contrib/create-basic-configdrive
@@ -78,11 +78,11 @@ chmod +x create-basic-configdrive
 ./create-basic-configdrive -H my_vm01 -S ~/.ssh/id_rsa.pub
 ```
 
-Will be created an ISO file named `my_vm01.iso` that will configure a virtual machine to accept your SSH key and set its name to my_vm01.
+An ISO file named `my_vm01.iso` will be created that will configure a virtual machine to accept your SSH key and set its name to my_vm01.
 
 ## Deploying a new virtual machine on VirtualBox
 
-I recommend using the built image as base image. Therefore you should clone the image for each new virtual machine and set it to desired size.
+Use the built image as the base image. Clone that image for each new virtual machine and set the desired size.
 
 ```sh
 VBoxManage clonehd coreos_production_stable.vdi my_vm01.vdi
@@ -90,25 +90,25 @@ VBoxManage clonehd coreos_production_stable.vdi my_vm01.vdi
 VBoxManage modifyhd my_vm01.vdi --resize 10240
 ```
 
-At boot time the Container Linux will detect that the volume size changed and will resize the filesystem according.
+At boot time, the Container Linux will detect that the volume size has changed and will resize the filesystem accordingly.
 
-Open VirtualBox Manager and go to menu Machine > New. Type the desired machine name and choose 'Linux' type and 'Linux 2.6 / 3.x (64 bit)' version.
+Open VirtualBox Manager and go to Machine > New. Type the desired machine name and choose 'Linux' as the type and 'Linux 2.6 / 3.x (64 bit)' as the version.
 
-Next, choose the desired memory size. I recommend 1 GB for smooth experience.
+Next, choose the desired memory size; at least 1 GB for an optimal experience.
 
-Next, choose 'Use an existing virtual hard drive file' and find the new cloned image.
+Then, choose 'Use an existing virtual hard drive file' and find the new cloned image.
 
-Click on 'Create' button to create the virtual machine.
+Click on the 'Create' button to create the virtual machine.
 
-Next, go to settings from the created virtual machine. Then click on Storage tab and load the created config-drive into CD/DVD drive.
+Next, go to the settings from the created virtual machine. Then click on the Storage tab and load the created config-drive into the CD/DVD drive.
 
-Click on 'OK' button and the virtual machine will be ready to be started.
+Click on the 'OK' button and the virtual machine will be ready to be started.
 
 ## Logging in
 
-Networking can take a bit of time to come up under VirtualBox and you will need to know the IP in order to connect to it. Press enter a few times at the login prompt to see an IP address pop up. If you see VirtualBox NAT IP 10.0.2.15, go to virtual machine settings and click the Network tab, then Port Forwarding. Add the rule "Host Port: 2222; Guest Port 22", then connect using the command ssh `core@localhost -p2222`.
+Networking can take a bit of time to come up under VirtualBox, and the IP is needed in order to connect to it. Press enter a few times at the login prompt to see an IP address pop up. If you see VirtualBox NAT IP 10.0.2.15, go to the virtual machine settings and click the Network tab then Port Forwarding. Add the rule "Host Port: 2222; Guest Port 22" then connect using the command `ssh core@localhost -p2222`.
 
-Now you can login using your private SSH key.
+Now, login using your private SSH key.
 
 ```sh
 ssh core@192.168.56.101
@@ -116,4 +116,4 @@ ssh core@192.168.56.101
 
 ## Using CoreOS Container Linux
 
-Now that you have a machine booted it is time to play around. Check out the [Container Linux Quickstart](quickstart.md) guide or dig into [more specific topics](https://coreos.com/docs).
+Now that the machine has booted, it is time to play around. Check out the [Container Linux Quickstart](quickstart.md) guide or dig into [more specific topics](https://coreos.com/docs).


### PR DESCRIPTION
Made changes to the Virtualbox instructions because there were many syntactical and grammatical errors. Fixed those up and also changed a few first-person pronoun references.