### PR TITLE
Add `bzip2` requirement to instructions

### DIFF
--- a/os/sdk-modifying-coreos.md
+++ b/os/sdk-modifying-coreos.md
@@ -17,6 +17,7 @@ System requirements to get started:
 * curl
 * git
 * python2
+* bzip2
 
 You also need a proper git setup:
 


### PR DESCRIPTION
`cork` uses it as part of `cork create`.