### PR TITLE
os/sdk-modifying-coreos: update system requirements

### DIFF
--- a/os/sdk-modifying-coreos.md
+++ b/os/sdk-modifying-coreos.md
@@ -16,8 +16,9 @@ System requirements to get started:
 
 * curl
 * git
-* python2
 * bzip2
+* gpg
+* sudo
 
 You also need a proper git setup:
 


### PR DESCRIPTION
Add gpg. Drop python2 now that we only support cork.