### PR TITLE
os/guid: document constants and ids

### DIFF
--- a/os/constants-and-ids.md
+++ b/os/constants-and-ids.md
@@ -1,0 +1,24 @@
+# Constants and IDs
+
+This document contains well-known constants and IDs used by Container Linux.
+
+## Omaha application ID
+
+This UUID is used to identify Container Linux to the update service, i.e. as an `appid` over the [Omaha protocol](../coreupdate/update-protocol.md).
+
+| Label            | Value                                  | Notes |
+|------------------|----------------------------------------|-------|
+| Container Linux  | `e96281a6-d1af-4bde-9a0a-97b76e56dc57` | -     |
+
+## GPT partition types
+
+These GUIDs are dedicated [GPT partition types](https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs) for specific Container Linux usages.
+
+| Label              | Value                                  | Notes |
+|--------------------|----------------------------------------|-------|
+| `coreos-usr`       | `5dfbf5f4-2848-4bac-aa5e-0d9a20b745a6` | Alias for historical `coreos-rootfs`, currently used for `/usr` only |
+| `coreos-resize`    | `3884dd41-8582-4404-b9a8-e9b84f2df50e` | Support for auto-resizing via `extend-filesystems`, current default type for `/` |
+| `coreos-reserved`  | `c95dc21a-df0e-4340-8d7b-26cbfa9a03e0` | Reserved for OEM usage, support for customizations via `OEM-CONFIG` partition |
+| `coreos-root-raid` | `be9067b9-ea49-4f15-b4f6-f36f8c9e1818` | RAID partition containing a rootfs, see [notes](../os/root-filesystem-placement.md) for details and limitations |
+
+For more information on the partitioning scheme used by Container Linux, read the [disk layout](../os/sdk-disk-partitions.md) documentation.

--- a/os/sdk-tips-and-tricks.md
+++ b/os/sdk-tips-and-tricks.md
@@ -192,19 +192,3 @@ To avoid corrupting the ccache, do not abort builds.
 ### `build_image` hangs while emerging packages after previously aborting a build
 
 Delete all `*.portage_lockfile`s in `/build/<arch>/`. To avoid stale lockfiles, do not abort builds.
-
-## Constants and IDs
-
-### CoreOS Container Linux app ID
-
-This UUID is used to identify Container Linux to the update service and elsewhere.
-
-```
-e96281a6-d1af-4bde-9a0a-97b76e56dc57
-```
-
-### GPT UUID types
-
-- CoreOS Root: 5dfbf5f4-2848-4bac-aa5e-0d9a20b745a6
-- CoreOS Reserved: c95dc21a-df0e-4340-8d7b-26cbfa9a03e0
-- CoreOS Raid Containing Root: be9067b9-ea49-4f15-b4f6-f36f8c9e1818


### PR DESCRIPTION
This collects constants used by ContainerLinux into a dedicated page, expanding the list of all reserved IDs together with short explanations.