### PR TITLE
quay: clean up links to reference local resources

### DIFF
--- a/quay-enterprise/custom-cert-kube-apps.md
+++ b/quay-enterprise/custom-cert-kube-apps.md
@@ -36,6 +36,6 @@ Client-version: 0.3.7
 [appr]: https://github.com/app-registry/appr
 [self-signed]: quay-ssl.md
 [python-requests]: http://docs.python-requests.org/en/master/
-[container-linux]: https://coreos.com/os/docs/latest/adding-certificate-authorities.html
+[container-linux]: https://github.com/coreos/docs/blob/master/os/adding-certificate-authorities.md
 [red-hat]: https://access.redhat.com/solutions/1519813
 [ubuntu]: https://askubuntu.com/questions/73287/how-do-i-install-a-root-certificate

--- a/quay-enterprise/high-availability.md
+++ b/quay-enterprise/high-availability.md
@@ -15,7 +15,7 @@ The following services are required in order to run Quay Enterprise as HA:
 
 ## Basic setup
 
-Perform the basic [Quay Enterprise Setup](https://tectonic.com/quay-enterprise/docs/latest/initial-setup.html) process, using the above database, storage, redis and using the *load balancer hostname* as the server hostname. Once complete, save the contents of the `conf/stack` directory.
+Perform the basic [Quay Enterprise Setup](initial-setup.md) process, using the above database, storage, redis and using the *load balancer hostname* as the server hostname. Once complete, save the contents of the `conf/stack` directory.
 
 ## High Availability Setup
 

--- a/quay-enterprise/quay-ssl.md
+++ b/quay-enterprise/quay-ssl.md
@@ -134,5 +134,5 @@ latest: digest: sha256:c24be6d92b0a4e2bb8a8cc7c9bd044278d6abdf31534729b1660a485b
 ```
 
 
-[qe-single]: https://tectonic.com/quay-enterprise/docs/latest/initial-setup.html
+[qe-single]: initial-setup.md
 [self-signed-cert]: https://en.wikipedia.org/wiki/Self-signed_certificate

--- a/quay-enterprise/upgrade-quay-enterprise.md
+++ b/quay-enterprise/upgrade-quay-enterprise.md
@@ -60,4 +60,4 @@ Visit the /health/endtoend endpoint on the registry hostname and verify that the
 If the upgraded container is healthy, repeat this process for all remaining Quay Enterprise containers.
 
 
-[qe-releases]: https://tectonic.com/quay-enterprise/releases/
+[qe-releases]: https://coreos.com/quay-enterprise/releases/

--- a/quay-enterprise/upgrade-quay.md
+++ b/quay-enterprise/upgrade-quay.md
@@ -1,6 +1,6 @@
 # Upgrading Quay Enterprise
 
-The full list of Quay Enterprise versions can be found on the [Quay Enterprise Releases](https://tectonic.com/quay-enterprise/releases/) page.
+The full list of Quay Enterprise versions can be found on the [Quay Enterprise Releases][releases] page.
 
 ### Special Note: Upgrading from Quay Enterprise < 2.0.0 to >= 2.0.0
 
@@ -12,7 +12,7 @@ We **highly** recommend performing upgrades during a scheduled maintainence wind
 
 ## The upgrade process
 
-1. Visit the [Quay Enterprise Releases](https://tectonic.com/quay-enterprise/releases/) page and note the latest version of Quay Enterprise.
+1. Visit the [Quay Enterprise Releases][releases] page and note the latest version of Quay Enterprise.
 2. Shutdown the Quay Enterprise cluster: Remove **all** containers from service.
 3. On a **single** node, run the newer version of Quay Enterprise.
 4. Quay Enterprise will perform any necessary database migrations before bringing itself back into service.
@@ -24,3 +24,5 @@ docker logs -f {containerId}
 ```
 
 5. Update all other nodes to refer to the new tag and bring them back into service.
+
+[releases]: https://coreos.com/quay-enterprise/releases/


### PR DESCRIPTION
The local resources can be referenced with a local path instead of a
tectonic.com URL.