### PR TITLE
os/disk: fix instructions for OS state removal

### DIFF
--- a/os/sdk-disk-partitions.md
+++ b/os/sdk-disk-partitions.md
@@ -48,4 +48,9 @@ All stateful data, including container images, is stored within the read/write f
 
 The data stored on the root partition isn't manipulated by the update process. In return, we do our best to prevent you from modifying the data in /usr.
 
-Due to the unique disk layout of Container Linux, an `rm -rf /` is an un-supported but valid operation to do a "factory reset". The machine should boot and operate normally afterwards.
+Due to the unique disk layout of Container Linux, an `rm -rf --one-file-system --no-preserve-root /` is an unsupported but valid operation to purge any OS data. On the next boot, the machine should just start from a clean state.
+
+To [re-provision][provisioning] the node after such cleanup, use `touch /boot/coreos/first_boot` to trigger Ignition [to run once][boot process] again on the next boot.
+
+[provisioning]: ../os/provisioning.md
+[boot process]: ../ignition/boot-process.md


### PR DESCRIPTION
This fixes the instructions describing how to purge all OS state.
It also avoid using the "factory reset" term, as the initial rootfs
partition we ship as of now is not completely empty.

Fixes https://github.com/coreos/bugs/issues/2370