### PR TITLE
change redis image to use redis:4 (version 4.0.9)

### DIFF
--- a/quay-enterprise/tectonic/files/quay-enterprise-redis.yml
+++ b/quay-enterprise/tectonic/files/quay-enterprise-redis.yml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: redis-master
-        image: quay.io/quay/redis
+        image: redis:4
         ports:
         - containerPort: 6379
 ---


### PR DESCRIPTION
 quay.io/quay/redis contains over 491 vulnerabilities - including shellshock. great for clair demo'ing though.