### PR TITLE
os/kernel-modules: Use /etc/fstab instead of mount units

### DIFF
--- a/os/kernel-modules.md
+++ b/os/kernel-modules.md
@@ -12,28 +12,10 @@ sudo mount \
     -t overlay overlay /lib/modules
 ```
 
-The following systemd unit can be written to `/etc/systemd/system/lib-modules.mount`.
+To mount the overlay automatically when the system boots, add the following line to `/etc/fstab` (creating it if necessary).
 
-```ini
-[Unit]
-Description=Custom Kernel Modules
-Before=local-fs.target
-ConditionPathExists=/opt/modules
-
-[Mount]
-Type=overlay
-What=overlay
-Where=/lib/modules
-Options=lowerdir=/lib/modules,upperdir=/opt/modules,workdir=/opt/modules.wd
-
-[Install]
-WantedBy=local-fs.target
 ```
-
-Enable the unit so this overlay is mounted automatically on boot.
-
-```sh
-sudo systemctl enable lib-modules.mount
+overlay /lib/modules overlay lowerdir=/lib/modules,upperdir=/opt/modules,workdir=/opt/modules.wd,nofail 0 0
 ```
 
 ## Prepare a CoreOS Container Linux development container


### PR DESCRIPTION
Starting with systemd 238, mount units will fail if the mount point needs to follow symbolic links.  Since we have all of the lib dirs symlinked together, /lib/modules is really /usr/lib64/modules, and that makes this example mount unit fail to start.  The fstab generator normalizes paths before writing its mounts units, so that is a reliable alternative.

For coreos/bugs#2407