### PR TITLE
Fix flannel unit-file url

### DIFF
--- a/flannel/flannel-config.md
+++ b/flannel/flannel-config.md
@@ -74,7 +74,7 @@ To reduce the Container Linux image size, flannel daemon is stored in CoreOS Ent
 
 Here is the sequence of events that happens when `flanneld.service` is started followed by a service that runs a Docker container (e.g. redis server):
 
-1. `flanneld.service` gets started and executes `/usr/bin/rkt run --net=host quay.io/coreos/flannel:$FLANNEL_VER` (the actual invocation is slightly more complex; the full version can be seen [here](https://github.com/coreos/coreos-overlay/blob/master/app-admin/flannel/files/flanneld.service) or by running `systemctl cat flanneld.service`, which also includes any drop in units).
+1. `flanneld.service` gets started and executes `/usr/bin/rkt run --net=host quay.io/coreos/flannel:$FLANNEL_VER` (the actual invocation is slightly more complex; the full version can be seen [here](https://github.com/coreos/coreos-overlay/blob/master/app-admin/flannel-wrapper/files/flanneld.service) or by running `systemctl cat flanneld.service`, which also includes any drop in units).
 2. flanneld starts and writes out `/run/flannel/subnet.env` with the acquired IP subnet information.
 3. `ExecStartPost` in `flanneld.service` converts information in `/run/flannel/subnet.env` into Docker daemon command line args (such as `--bip` and `--mtu`), storing them in `/run/flannel/flannel_docker_opts.env`.
 4. `redis.service` gets started which invokes `docker run ...`, triggering socket activation of `docker.service`.


### PR DESCRIPTION
The current documentation points to incorrect (old?) URL, some serious inconvenience for lazy people like me.