### PR TITLE
os: Update systemd config example to include mkswap

### DIFF
--- a/os/adding-swap.md
+++ b/os/adding-swap.md
@@ -114,5 +114,6 @@ systemd:
         ExecStart=/usr/bin/mkdir -p /var/vm
         ExecStart=/usr/bin/fallocate -l 1024m /var/vm/swapfile1
         ExecStart=/usr/bin/chmod 600 /var/vm/swapfile1
+        ExecStart=/usr/sbin/mkswap /var/vm/swapfile1
         RemainAfterExit=true
 ```


### PR DESCRIPTION
Make the systemd config include a mkswap statement for actually creating a swapfile in the first boot loader example. Without this, the .swap unit fails.