### PR TITLE
os/sdk-modifying-coreos: bump mantle version to 0.12.0

### DIFF
--- a/os/sdk-modifying-coreos.md
+++ b/os/sdk-modifying-coreos.md
@@ -36,8 +36,8 @@ The `cork` utility, included in the CoreOS [mantle](https://github.com/coreos/ma
 First, download the cork utility:
 
 ```sh
-curl -L -o cork https://github.com/coreos/mantle/releases/download/v0.11.1/cork-0.11.1-amd64
-curl -L -o cork.sig https://github.com/coreos/mantle/releases/download/v0.11.1/cork-0.11.1-amd64.sig
+curl -L -o cork https://github.com/coreos/mantle/releases/download/v0.12.0/cork-0.12.0-amd64
+curl -L -o cork.sig https://github.com/coreos/mantle/releases/download/v0.12.0/cork-0.12.0-amd64.sig
 ```
 
 Now, verify the download with the signature:  


### PR DESCRIPTION
The bits aren't published yet, but will be soon.